### PR TITLE
feat: Prontuário Eletrônico com assinatura, PDF e audit log (TDD 8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "axios": "^1.12.2",
         "bcrypt": "^6.0.0",
         "bcryptjs": "^3.0.2",
-        "better-sqlite3": "^11.0.0",
         "bullmq": "^5.71.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -33,6 +32,7 @@
         "node-cron": "^3.0.3",
         "node-fetch": "^2.7.0",
         "nodemailer": "^7.0.6",
+        "pdfkit": "^0.18.0",
         "pg": "^8.20.0",
         "qrcode": "^1.5.4",
         "qrcode-terminal": "^0.12.0",
@@ -2010,11 +2010,22 @@
         "win32"
       ]
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -3008,6 +3019,15 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
+      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -4142,17 +4162,6 @@
         "bcrypt": "bin/bcrypt"
       }
     },
-    "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      }
-    },
     "node_modules/big-integer": {
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -4286,6 +4295,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -4813,6 +4831,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clone-response": {
@@ -5435,6 +5462,12 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -6326,6 +6359,23 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/form-data": {
@@ -8197,6 +8247,12 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8467,6 +8523,25 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -9800,6 +9875,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9880,6 +9961,20 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/pdfkit": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.18.0.tgz",
+      "integrity": "sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -10101,6 +10196,11 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/pngjs": {
       "version": "5.0.0",
@@ -10980,6 +11080,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.12.0",
@@ -12196,6 +12302,12 @@
         "real-require": "^0.2.0"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -12368,6 +12480,26 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unique-filename": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "node-cron": "^3.0.3",
     "node-fetch": "^2.7.0",
     "nodemailer": "^7.0.6",
+    "pdfkit": "^0.18.0",
     "pg": "^8.20.0",
     "qrcode": "^1.5.4",
     "qrcode-terminal": "^0.12.0",

--- a/src/app.js
+++ b/src/app.js
@@ -429,6 +429,8 @@ class SaeeApp {
     
     this.app.use('/api/prontuario', prontuarioRoutes); // prontuário médico schema-driven
     this.app.use('/api/prontuarios', prontuariosRoutes);
+    // Prontuário Eletrônico TDD (novo — PostgreSQL multi-tenant)
+    this.app.use('/api/prontuarios-v2', require('./routes/prontuarios-eletronico'));
     // this.app.use('/api/financeiro', financeiroRoutes); // ⚠️ SQLite (não usar)
     this.app.use('/api/financeiro', extractTenantFirestore, financeiroFirestoreRoutes); // ✅ FIRESTORE
     // this.app.use('/api/crm', crmRoutes); // ⚠️ SQLite (não usar)

--- a/src/middleware/prontuarioAudit.js
+++ b/src/middleware/prontuarioAudit.js
@@ -1,0 +1,40 @@
+// Middleware de audit log para prontuários — registra toda leitura e escrita
+function auditarProntuario(acao) {
+  return async (req, res, next) => {
+    const originalJson = res.json.bind(res);
+
+    res.json = async function (body) {
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        const prontuarioId = req.params?.id ?? body?.id ?? null;
+        if (prontuarioId && req.db) {
+          const userId = req.usuario?.id || req.user?.id;
+          const tenantId = req.tenantId || req.usuario?.tenant_slug;
+          try {
+            await req.db.run(
+              `INSERT INTO prontuario_audit_log
+                 (prontuario_id, tenant_id, usuario_id, acao, detalhes, ip, user_agent)
+               VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+              [
+                prontuarioId,
+                tenantId,
+                userId,
+                acao,
+                JSON.stringify({ url: req.url, params: req.params }),
+                req.ip || null,
+                req.get('User-Agent') || null,
+              ]
+            );
+          } catch (err) {
+            // Audit log nunca interrompe o fluxo
+            console.error('[prontuarioAudit] falha:', err.message);
+          }
+        }
+      }
+      return originalJson(body);
+    };
+
+    next();
+  };
+}
+
+module.exports = { auditarProntuario };

--- a/src/migrations/021_prontuarios.sql
+++ b/src/migrations/021_prontuarios.sql
@@ -1,0 +1,121 @@
+-- Migration 021: Prontuário Eletrônico (schema por tenant)
+
+CREATE TABLE IF NOT EXISTS prontuarios (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id        UUID NOT NULL,
+  paciente_id      BIGINT NOT NULL REFERENCES pacientes(id) ON DELETE RESTRICT,
+  profissional_id  BIGINT NOT NULL REFERENCES profissionais(id) ON DELETE RESTRICT,
+  atendimento_id   BIGINT,
+  tipo_atendimento VARCHAR(30) NOT NULL DEFAULT 'consulta'
+                     CHECK (tipo_atendimento IN ('consulta','retorno','procedimento','telemedicina')),
+  status           VARCHAR(20) NOT NULL DEFAULT 'draft'
+                     CHECK (status IN ('draft','assinado')),
+  triagem_json     JSONB,
+  assinado_por     BIGINT REFERENCES profissionais(id),
+  assinado_em      TIMESTAMPTZ,
+  criado_por       BIGINT NOT NULL,
+  criado_em        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  atualizado_em    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_prontuarios_tenant        ON prontuarios (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_prontuarios_paciente      ON prontuarios (tenant_id, paciente_id);
+CREATE INDEX IF NOT EXISTS idx_prontuarios_profissional  ON prontuarios (tenant_id, profissional_id);
+CREATE INDEX IF NOT EXISTS idx_prontuarios_status        ON prontuarios (tenant_id, status);
+
+-- Entradas por seção (uma por seção, exceto adendo que pode ser múltiplo)
+CREATE TABLE IF NOT EXISTS prontuario_entradas (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prontuario_id UUID NOT NULL REFERENCES prontuarios(id) ON DELETE CASCADE,
+  tenant_id     UUID NOT NULL,
+  secao         VARCHAR(30) NOT NULL
+                  CHECK (secao IN ('anamnese','exame_fisico','hipotese_diagnostica',
+                                   'conduta','procedimentos_realizados','adendo')),
+  conteudo_json JSONB NOT NULL DEFAULT '{}',
+  versao        INT NOT NULL DEFAULT 1,
+  autor_id      BIGINT NOT NULL,
+  criado_em     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  atualizado_em TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Índice parcial único: 1 entrada por seção (exceto adendo)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pront_entradas_secao_unico
+  ON prontuario_entradas (prontuario_id, secao)
+  WHERE secao != 'adendo';
+
+CREATE INDEX IF NOT EXISTS idx_pront_entradas_prontuario ON prontuario_entradas (prontuario_id);
+
+-- Prescrições
+CREATE TABLE IF NOT EXISTS prontuario_prescricoes (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prontuario_id UUID NOT NULL REFERENCES prontuarios(id) ON DELETE CASCADE,
+  tenant_id     UUID NOT NULL,
+  medicamento   VARCHAR(255) NOT NULL,
+  dose          VARCHAR(100),
+  frequencia    VARCHAR(100),
+  duracao       VARCHAR(100),
+  via           VARCHAR(50),
+  observacoes   TEXT,
+  ordem         INT NOT NULL DEFAULT 0,
+  criado_em     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pront_prescricoes_prontuario ON prontuario_prescricoes (prontuario_id);
+
+-- CIDs
+CREATE TABLE IF NOT EXISTS prontuario_cids (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prontuario_id UUID NOT NULL REFERENCES prontuarios(id) ON DELETE CASCADE,
+  tenant_id     UUID NOT NULL,
+  cid_codigo    VARCHAR(10) NOT NULL,
+  cid_descricao VARCHAR(255) NOT NULL,
+  tipo          VARCHAR(20) NOT NULL DEFAULT 'principal'
+                  CHECK (tipo IN ('principal','secundario')),
+  status_cid    VARCHAR(20) NOT NULL DEFAULT 'hipotese'
+                  CHECK (status_cid IN ('hipotese','confirmado','descartado')),
+  criado_em     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pront_cids_prontuario ON prontuario_cids (prontuario_id);
+
+-- Anexos
+CREATE TABLE IF NOT EXISTS prontuario_anexos (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prontuario_id UUID NOT NULL REFERENCES prontuarios(id) ON DELETE CASCADE,
+  tenant_id     UUID NOT NULL,
+  nome_arquivo  VARCHAR(255) NOT NULL,
+  url           TEXT NOT NULL,
+  tipo_mime     VARCHAR(100),
+  tamanho_bytes INT,
+  enviado_por   BIGINT NOT NULL,
+  criado_em     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pront_anexos_prontuario ON prontuario_anexos (prontuario_id);
+
+-- Audit log
+CREATE TABLE IF NOT EXISTS prontuario_audit_log (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prontuario_id UUID NOT NULL REFERENCES prontuarios(id) ON DELETE CASCADE,
+  tenant_id     UUID NOT NULL,
+  usuario_id    BIGINT NOT NULL,
+  acao          VARCHAR(50) NOT NULL
+                  CHECK (acao IN ('leitura','criacao','edicao','assinatura','exportacao_pdf','upload_anexo')),
+  detalhes      JSONB,
+  ip            VARCHAR(45),
+  user_agent    TEXT,
+  criado_em     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_prontuario   ON prontuario_audit_log (prontuario_id);
+CREATE INDEX IF NOT EXISTS idx_audit_tenant_data  ON prontuario_audit_log (tenant_id, criado_em);
+
+-- CID-10 (schema público — compartilhado entre todos os tenants)
+CREATE TABLE IF NOT EXISTS public.cid10 (
+  codigo     VARCHAR(10)  PRIMARY KEY,
+  descricao  VARCHAR(500) NOT NULL,
+  categoria  VARCHAR(100)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cid10_descricao
+  ON public.cid10 USING GIN (to_tsvector('portuguese', descricao));

--- a/src/routes/prontuarios-eletronico.js
+++ b/src/routes/prontuarios-eletronico.js
@@ -1,0 +1,455 @@
+const express = require('express');
+const router = express.Router();
+const multer = require('multer');
+const { extractTenant } = require('../middleware/tenant');
+const { authenticateToken } = require('../middleware/auth');
+const { auditarProntuario } = require('../middleware/prontuarioAudit');
+const { gerarProntuarioPdf } = require('../services/ProntuarioPdfService');
+const HistoricoService = require('../services/HistoricoService');
+const storageService = require('../services/storageService');
+
+// Multer para anexos — 20MB, todos os tipos
+const uploadAnexo = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 20 * 1024 * 1024 },
+});
+
+// Helper: verifica se o perfil tem acesso a prontuários
+function requireProntuarioRead(req, res, next) {
+  const perfil = req.usuario?.perfil || req.user?.role;
+  const bloqueados = ['recepcionista', 'financeiro'];
+  if (bloqueados.includes(perfil)) {
+    return res.status(403).json({ error: 'Acesso negado a prontuários' });
+  }
+  next();
+}
+
+function requireProntuarioWrite(req, res, next) {
+  const perfil = req.usuario?.perfil || req.user?.role;
+  const permitidos = ['profissional', 'medico', 'owner', 'admin', 'admin_master'];
+  if (!permitidos.includes(perfil)) {
+    return res.status(403).json({ error: 'Sem permissão para editar prontuários' });
+  }
+  next();
+}
+
+function getTenantId(req) {
+  return req.tenantId || req.usuario?.tenant_slug || req.user?.tenantId;
+}
+
+function getUserId(req) {
+  return req.usuario?.id || req.user?.id;
+}
+
+function getPerfil(req) {
+  return req.usuario?.perfil || req.user?.role;
+}
+
+// ── GET /api/prontuarios-v2/cid10/buscar ──────────────────────────────────────
+router.get('/cid10/buscar', extractTenant, authenticateToken, async (req, res) => {
+  try {
+    const { q } = req.query;
+    if (!q || q.length < 2) {
+      return res.status(400).json({ error: 'Parâmetro q requerido (mín 2 caracteres)' });
+    }
+
+    const db = req.db;
+    const { rows } = await db.query(
+      `SELECT codigo, descricao FROM public.cid10
+       WHERE codigo ILIKE $1
+          OR to_tsvector('portuguese', descricao) @@ plainto_tsquery('portuguese', $2)
+       ORDER BY codigo
+       LIMIT 10`,
+      [`${q}%`, q]
+    );
+
+    return res.json({ data: rows });
+  } catch (err) {
+    console.error('❌ GET /cid10/buscar:', err);
+    return res.status(500).json({ error: 'Erro interno do servidor' });
+  }
+});
+
+// ── GET /api/prontuarios-v2/:paciente_id ──────────────────────────────────────
+router.get('/:paciente_id', extractTenant, authenticateToken, requireProntuarioRead,
+  auditarProntuario('leitura'),
+  async (req, res) => {
+    try {
+      const db = req.db;
+      if (!db) return res.status(400).json({ error: 'Tenant não especificado' });
+
+      const { paciente_id } = req.params;
+      const tenantId = getTenantId(req);
+      const userId = getUserId(req);
+      const perfil = getPerfil(req);
+      const page = parseInt(req.query.page) || 1;
+      const limit = parseInt(req.query.limit) || 10;
+      const offset = (page - 1) * limit;
+
+      // Verificar se paciente existe
+      const paciente = await db.get(
+        `SELECT id FROM pacientes WHERE id = $1`,
+        [paciente_id]
+      );
+      if (!paciente) return res.status(404).json({ error: 'Paciente não encontrado' });
+
+      const params = [paciente_id, tenantId];
+      let whereProfissional = '';
+
+      // Profissional vê apenas os seus próprios prontuários
+      if (perfil === 'profissional' || perfil === 'medico') {
+        params.push(userId);
+        whereProfissional = `AND pr.id = $${params.length}`;
+      }
+
+      params.push(limit, offset);
+
+      const rows = await db.all(`
+        SELECT
+          p.id,
+          p.paciente_id,
+          p.tipo_atendimento,
+          p.status,
+          p.criado_em,
+          p.assinado_em,
+          pr.id   AS profissional_id,
+          pr.nome AS profissional_nome,
+          pr.crm  AS profissional_crm
+        FROM prontuarios p
+        JOIN profissionais pr ON pr.id = p.profissional_id
+        WHERE p.paciente_id = $1
+          AND p.tenant_id = $2::uuid
+          ${whereProfissional}
+        ORDER BY p.criado_em DESC
+        LIMIT $${params.length - 1} OFFSET $${params.length}
+      `, params);
+
+      const countRow = await db.get(`
+        SELECT COUNT(*) AS total
+        FROM prontuarios p
+        WHERE p.paciente_id = $1 AND p.tenant_id = $2::uuid
+      `, [paciente_id, tenantId]);
+
+      const total = parseInt(countRow?.total || 0);
+
+      return res.json({
+        data: rows.map(r => ({
+          ...r,
+          profissional: { id: r.profissional_id, nome: r.profissional_nome, crm: r.profissional_crm },
+        })),
+        pagination: { page, limit, total, pages: Math.ceil(total / limit) },
+      });
+    } catch (err) {
+      console.error('❌ GET /prontuarios-v2/:paciente_id:', err);
+      return res.status(500).json({ error: 'Erro interno do servidor' });
+    }
+  }
+);
+
+// ── POST /api/prontuarios-v2 ──────────────────────────────────────────────────
+router.post('/', extractTenant, authenticateToken, requireProntuarioWrite,
+  auditarProntuario('criacao'),
+  async (req, res) => {
+    try {
+      const db = req.db;
+      if (!db) return res.status(400).json({ error: 'Tenant não especificado' });
+
+      const { paciente_id, atendimento_id, tipo_atendimento, triagem_json } = req.body;
+      const tenantId = getTenantId(req);
+      const userId = getUserId(req);
+
+      if (!paciente_id) return res.status(400).json({ error: 'paciente_id é obrigatório' });
+
+      const paciente = await db.get(
+        `SELECT id FROM pacientes WHERE id = $1`,
+        [paciente_id]
+      );
+      if (!paciente) return res.status(404).json({ error: 'Paciente não encontrado' });
+
+      const { rows: [prontuario] } = await db.query(`
+        INSERT INTO prontuarios
+          (tenant_id, paciente_id, profissional_id, atendimento_id, tipo_atendimento,
+           triagem_json, status, criado_por)
+        VALUES ($1::uuid, $2, $3, $4, $5, $6, 'draft', $7)
+        RETURNING id, status, criado_em
+      `, [
+        tenantId, paciente_id, userId,
+        atendimento_id || null,
+        tipo_atendimento || 'consulta',
+        triagem_json ? JSON.stringify(triagem_json) : null,
+        userId,
+      ]);
+
+      return res.status(201).json(prontuario);
+    } catch (err) {
+      console.error('❌ POST /prontuarios-v2:', err);
+      return res.status(500).json({ error: 'Erro interno do servidor' });
+    }
+  }
+);
+
+// ── PATCH /api/prontuarios-v2/:id/draft ───────────────────────────────────────
+router.patch('/:id/draft', extractTenant, authenticateToken, requireProntuarioWrite,
+  auditarProntuario('edicao'),
+  async (req, res) => {
+    try {
+      const db = req.db;
+      if (!db) return res.status(400).json({ error: 'Tenant não especificado' });
+
+      const { id } = req.params;
+      const tenantId = getTenantId(req);
+      const userId = getUserId(req);
+      const { entradas, prescricoes, cids } = req.body;
+
+      const prontuario = await db.get(
+        `SELECT id, status, profissional_id FROM prontuarios WHERE id = $1 AND tenant_id = $2::uuid`,
+        [id, tenantId]
+      );
+      if (!prontuario) return res.status(404).json({ error: 'Prontuário não encontrado' });
+
+      if (prontuario.status === 'assinado') {
+        return res.status(400).json({
+          error: 'Prontuário já assinado',
+          message: 'Não é possível editar um prontuário assinado. Use /adendo para adicionar informações.',
+        });
+      }
+
+      await db.transaction(async (client) => {
+        if (entradas) {
+          for (const [secao, conteudo] of Object.entries(entradas)) {
+            await client.query(`
+              INSERT INTO prontuario_entradas (prontuario_id, tenant_id, secao, conteudo_json, autor_id)
+              VALUES ($1, $2::uuid, $3, $4, $5)
+              ON CONFLICT (prontuario_id, secao) WHERE secao != 'adendo'
+              DO UPDATE SET
+                conteudo_json = EXCLUDED.conteudo_json,
+                versao = prontuario_entradas.versao + 1,
+                atualizado_em = now()
+            `, [id, tenantId, secao, JSON.stringify(conteudo), userId]);
+          }
+        }
+
+        if (prescricoes !== undefined) {
+          await client.query(`DELETE FROM prontuario_prescricoes WHERE prontuario_id = $1`, [id]);
+          for (let i = 0; i < prescricoes.length; i++) {
+            const p = prescricoes[i];
+            await client.query(`
+              INSERT INTO prontuario_prescricoes
+                (prontuario_id, tenant_id, medicamento, dose, frequencia, duracao, via, observacoes, ordem)
+              VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8, $9)
+            `, [id, tenantId, p.medicamento, p.dose || null, p.frequencia || null,
+                p.duracao || null, p.via || null, p.observacoes || null, i]);
+          }
+        }
+
+        if (cids !== undefined) {
+          await client.query(`DELETE FROM prontuario_cids WHERE prontuario_id = $1`, [id]);
+          for (const c of cids) {
+            await client.query(`
+              INSERT INTO prontuario_cids
+                (prontuario_id, tenant_id, cid_codigo, cid_descricao, tipo, status_cid)
+              VALUES ($1, $2::uuid, $3, $4, $5, $6)
+            `, [id, tenantId, c.cid_codigo, c.cid_descricao,
+                c.tipo || 'principal', c.status_cid || 'hipotese']);
+          }
+        }
+
+        await client.query(
+          `UPDATE prontuarios SET atualizado_em = now() WHERE id = $1`,
+          [id]
+        );
+      });
+
+      return res.json({ id, status: 'draft', atualizado_em: new Date().toISOString() });
+    } catch (err) {
+      console.error('❌ PATCH /prontuarios-v2/:id/draft:', err);
+      return res.status(500).json({ error: 'Erro interno do servidor' });
+    }
+  }
+);
+
+// ── POST /api/prontuarios-v2/:id/assinar ─────────────────────────────────────
+router.post('/:id/assinar', extractTenant, authenticateToken,
+  auditarProntuario('assinatura'),
+  async (req, res) => {
+    try {
+      const db = req.db;
+      if (!db) return res.status(400).json({ error: 'Tenant não especificado' });
+
+      const { id } = req.params;
+      const tenantId = getTenantId(req);
+      const userId = getUserId(req);
+      const perfil = getPerfil(req);
+
+      const prontuario = await db.get(
+        `SELECT id, status, paciente_id, profissional_id FROM prontuarios
+         WHERE id = $1 AND tenant_id = $2::uuid`,
+        [id, tenantId]
+      );
+      if (!prontuario) return res.status(404).json({ error: 'Prontuário não encontrado' });
+      if (prontuario.status === 'assinado') {
+        return res.status(400).json({ error: 'Prontuário já assinado' });
+      }
+
+      // Profissional só pode assinar seus próprios prontuários
+      if ((perfil === 'profissional' || perfil === 'medico') &&
+          String(prontuario.profissional_id) !== String(userId)) {
+        return res.status(403).json({ error: 'Apenas o profissional autor pode assinar este prontuário' });
+      }
+
+      await db.run(
+        `UPDATE prontuarios
+         SET status = 'assinado', assinado_por = $1, assinado_em = now(), atualizado_em = now()
+         WHERE id = $2 AND tenant_id = $3::uuid`,
+        [userId, id, tenantId]
+      );
+
+      await HistoricoService.registrar({
+        db, tenantId,
+        pacienteId: prontuario.paciente_id,
+        tipoEvento: 'prontuario_assinado',
+        referenciaId: id,
+        referenciaTabela: 'prontuarios',
+        descricao: 'Entrada de prontuário assinada pelo profissional',
+        usuarioId: userId,
+      });
+
+      return res.json({
+        id,
+        status: 'assinado',
+        assinado_em: new Date().toISOString(),
+        message: 'Prontuário assinado com sucesso',
+      });
+    } catch (err) {
+      console.error('❌ POST /prontuarios-v2/:id/assinar:', err);
+      return res.status(500).json({ error: 'Erro interno do servidor' });
+    }
+  }
+);
+
+// ── POST /api/prontuarios-v2/:id/adendo ──────────────────────────────────────
+router.post('/:id/adendo', extractTenant, authenticateToken, requireProntuarioWrite,
+  async (req, res) => {
+    try {
+      const db = req.db;
+      if (!db) return res.status(400).json({ error: 'Tenant não especificado' });
+
+      const { id } = req.params;
+      const tenantId = getTenantId(req);
+      const userId = getUserId(req);
+      const { conteudo } = req.body;
+
+      if (!conteudo) return res.status(400).json({ error: 'conteudo é obrigatório' });
+
+      const prontuario = await db.get(
+        `SELECT id FROM prontuarios WHERE id = $1 AND tenant_id = $2::uuid`,
+        [id, tenantId]
+      );
+      if (!prontuario) return res.status(404).json({ error: 'Prontuário não encontrado' });
+
+      const { rows: [adendo] } = await db.query(`
+        INSERT INTO prontuario_entradas
+          (prontuario_id, tenant_id, secao, conteudo_json, autor_id)
+        VALUES ($1, $2::uuid, 'adendo', $3, $4)
+        RETURNING id, criado_em
+      `, [id, tenantId, JSON.stringify({ texto: conteudo }), userId]);
+
+      return res.status(201).json({
+        id_adendo:    adendo.id,
+        prontuario_id: id,
+        criado_em:    adendo.criado_em,
+      });
+    } catch (err) {
+      console.error('❌ POST /prontuarios-v2/:id/adendo:', err);
+      return res.status(500).json({ error: 'Erro interno do servidor' });
+    }
+  }
+);
+
+// ── GET /api/prontuarios-v2/:id/pdf ──────────────────────────────────────────
+router.get('/:id/pdf', extractTenant, authenticateToken, requireProntuarioRead,
+  auditarProntuario('exportacao_pdf'),
+  async (req, res) => {
+    try {
+      const db = req.db;
+      if (!db) return res.status(400).json({ error: 'Tenant não especificado' });
+
+      const { id } = req.params;
+      const tenantId = getTenantId(req);
+
+      const prontuario = await db.get(`
+        SELECT p.*, pac.nome AS paciente_nome, pr.nome AS profissional_nome, pr.crm AS profissional_crm
+        FROM prontuarios p
+        JOIN pacientes pac ON pac.id = p.paciente_id
+        JOIN profissionais pr ON pr.id = p.profissional_id
+        WHERE p.id = $1 AND p.tenant_id = $2::uuid
+      `, [id, tenantId]);
+
+      if (!prontuario) return res.status(404).json({ error: 'Prontuário não encontrado' });
+
+      const [entradas, prescricoes, cids] = await Promise.all([
+        db.all(`SELECT secao, conteudo_json, versao, criado_em FROM prontuario_entradas WHERE prontuario_id = $1 ORDER BY criado_em ASC`, [id]),
+        db.all(`SELECT * FROM prontuario_prescricoes WHERE prontuario_id = $1 ORDER BY ordem ASC`, [id]),
+        db.all(`SELECT * FROM prontuario_cids WHERE prontuario_id = $1`, [id]),
+      ]);
+
+      const pdfBuffer = await gerarProntuarioPdf({ ...prontuario, entradas, prescricoes, cids });
+
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', `attachment; filename="prontuario-${id}.pdf"`);
+      return res.send(pdfBuffer);
+    } catch (err) {
+      console.error('❌ GET /prontuarios-v2/:id/pdf:', err);
+      return res.status(500).json({ error: 'Erro interno do servidor' });
+    }
+  }
+);
+
+// ── POST /api/prontuarios-v2/:id/anexos ──────────────────────────────────────
+router.post('/:id/anexos', extractTenant, authenticateToken, requireProntuarioWrite,
+  uploadAnexo.single('arquivo'),
+  auditarProntuario('upload_anexo'),
+  async (req, res) => {
+    try {
+      const db = req.db;
+      if (!db) return res.status(400).json({ error: 'Tenant não especificado' });
+
+      if (!req.file) return res.status(400).json({ error: 'Arquivo é obrigatório' });
+
+      const { id } = req.params;
+      const tenantId = getTenantId(req);
+      const userId = getUserId(req);
+
+      const prontuario = await db.get(
+        `SELECT id FROM prontuarios WHERE id = $1 AND tenant_id = $2::uuid`,
+        [id, tenantId]
+      );
+      if (!prontuario) return res.status(404).json({ error: 'Prontuário não encontrado' });
+
+      const filename = `${Date.now()}-${req.file.originalname.replace(/\s/g, '_')}`;
+      const url = await storageService.uploadPacienteFoto(
+        `prontuarios/${tenantId}`,
+        req.file.buffer,
+        filename
+      );
+
+      const { rows: [anexo] } = await db.query(`
+        INSERT INTO prontuario_anexos
+          (prontuario_id, tenant_id, nome_arquivo, url, tipo_mime, tamanho_bytes, enviado_por)
+        VALUES ($1, $2::uuid, $3, $4, $5, $6, $7)
+        RETURNING id, nome_arquivo, url, tamanho_bytes
+      `, [id, tenantId, req.file.originalname, url,
+          req.file.mimetype, req.file.size, userId]);
+
+      return res.status(201).json(anexo);
+    } catch (err) {
+      if (err.code === 'LIMIT_FILE_SIZE') {
+        return res.status(413).json({ error: 'Arquivo excede o limite de 20MB' });
+      }
+      console.error('❌ POST /prontuarios-v2/:id/anexos:', err);
+      return res.status(500).json({ error: 'Erro interno do servidor' });
+    }
+  }
+);
+
+module.exports = router;

--- a/src/services/HistoricoService.js
+++ b/src/services/HistoricoService.js
@@ -1,0 +1,15 @@
+// Serviço de histórico do paciente — registra eventos após assinatura de prontuário
+async function registrar({ db, tenantId, pacienteId, tipoEvento, referenciaId, referenciaTabela, descricao, usuarioId }) {
+  try {
+    await db.run(`
+      INSERT INTO prontuario_registros
+        (paciente_id, tipo_evento, referencia_id, referencia_tabela, descricao, criado_por, data_registro)
+      VALUES ($1, $2, $3, $4, $5, $6, now())
+    `, [pacienteId, tipoEvento, referenciaId, referenciaTabela, descricao, usuarioId]);
+  } catch (err) {
+    // Histórico é não-crítico — não interromper o fluxo
+    console.error('[HistoricoService] falha ao registrar:', err.message);
+  }
+}
+
+module.exports = { registrar };

--- a/src/services/ProntuarioPdfService.js
+++ b/src/services/ProntuarioPdfService.js
@@ -1,0 +1,69 @@
+const PDFDocument = require('pdfkit');
+
+async function gerarProntuarioPdf(prontuarioCompleto) {
+  return new Promise((resolve, reject) => {
+    const doc = new PDFDocument({ margin: 50, size: 'A4' });
+    const chunks = [];
+    doc.on('data', (chunk) => chunks.push(chunk));
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+    doc.on('error', reject);
+
+    // Cabeçalho
+    doc.fontSize(18).text('AltClinic — Prontuário Eletrônico', { align: 'center' });
+    doc.moveDown();
+    doc.fontSize(11).text(`Paciente: ${prontuarioCompleto.paciente_nome}`);
+    doc.text(`Profissional: ${prontuarioCompleto.profissional_nome}${prontuarioCompleto.profissional_crm ? ' — CRM: ' + prontuarioCompleto.profissional_crm : ''}`);
+    doc.text(`Data: ${prontuarioCompleto.assinado_em ? new Date(prontuarioCompleto.assinado_em).toLocaleString('pt-BR') : new Date(prontuarioCompleto.criado_em).toLocaleString('pt-BR')}`);
+    doc.text(`Tipo: ${prontuarioCompleto.tipo_atendimento}`);
+    doc.text(`Status: ${prontuarioCompleto.status}`);
+    doc.moveDown();
+    doc.moveTo(50, doc.y).lineTo(545, doc.y).stroke();
+    doc.moveDown();
+
+    // Seções
+    for (const entrada of (prontuarioCompleto.entradas || [])) {
+      doc.fontSize(13).text(
+        entrada.secao.replace(/_/g, ' ').toUpperCase(),
+        { underline: true }
+      );
+      const conteudo = entrada.conteudo_json;
+      if (typeof conteudo === 'string') {
+        doc.fontSize(10).text(conteudo);
+      } else {
+        doc.fontSize(10).text(JSON.stringify(conteudo, null, 2));
+      }
+      doc.moveDown();
+    }
+
+    // Prescrições
+    if (prontuarioCompleto.prescricoes?.length) {
+      doc.fontSize(13).text('PRESCRIÇÕES', { underline: true });
+      prontuarioCompleto.prescricoes.forEach((p, i) => {
+        const linha = [
+          `${i + 1}. ${p.medicamento}`,
+          p.dose ? `— ${p.dose}` : '',
+          p.frequencia ? `${p.frequencia}` : '',
+          p.duracao ? `por ${p.duracao}` : '',
+          p.via ? `(${p.via})` : '',
+        ].filter(Boolean).join(' ');
+        doc.fontSize(10).text(linha);
+      });
+      doc.moveDown();
+    }
+
+    // CIDs
+    if (prontuarioCompleto.cids?.length) {
+      doc.fontSize(13).text('CID-10', { underline: true });
+      prontuarioCompleto.cids.forEach((c) => {
+        doc.fontSize(10).text(
+          `${c.cid_codigo} — ${c.cid_descricao} (${c.tipo} / ${c.status_cid})`
+        );
+      });
+      doc.moveDown();
+    }
+
+    doc.end();
+  });
+}
+
+module.exports = { gerarProntuarioPdf };


### PR DESCRIPTION
## O que foi feito

- **Migration 021**: 6 tabelas + `public.cid10`
  - `prontuarios` (draft/assinado, imutável após assinatura)
  - `prontuario_entradas` com índice único parcial (excluindo adendo — permite múltiplos adendos)
  - `prontuario_prescricoes`, `prontuario_cids`, `prontuario_anexos`
  - `prontuario_audit_log` com índice GIN full-text portuguese para CID-10
- **prontuarioAudit.js**: middleware que intercepta `res.json` após 2xx e registra ação (não bloqueia fluxo)
- **ProntuarioPdfService.js**: geração de PDF com `pdfkit` — seções, prescrições, CIDs
- **HistoricoService.js**: stub que registra em `prontuario_registros` com try/catch (não-crítico)
- **prontuarios-eletronico.js** — 8 endpoints em `/api/prontuarios-v2`
  - `GET /:paciente_id` — RBAC bloqueia recepcionista/financeiro; profissional vê só os seus
  - `POST /` — cria em draft
  - `PATCH /:id/draft` — auto-save com upsert por seção (ON CONFLICT com partial index)
  - `POST /:id/assinar` — torna imutável, registra HistoricoService
  - `POST /:id/adendo` — sempre INSERT novo (não conflita com partial unique index)
  - `GET /:id/pdf` — gera PDF via pdfkit (stream)
  - `POST /:id/anexos` — multer 20MB → Firebase Storage
  - `GET /cid10/buscar` — full-text PostgreSQL (GIN index)
- **pdfkit** instalado como dependência

## Nota
Rota registrada em `/api/prontuarios-v2` para evitar conflito com a rota legacy `/api/prontuarios`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)