### PR TITLE
feat: Relatório de Receita — Analytics + Export + Insights IA (TDD20)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -57,6 +57,7 @@ require('./jobs/faturasVencidas').register();   // Marcar faturas vencidas às 0
 require('./jobs/qrExpirar').register();         // Expirar QR codes vencidos (1min) + fallback polling (10min)
 require('./jobs/iaScores').register();          // Scores de risco financeiro IA às 06:00 diário
 require('./jobs/iaInsights').register();        // Insights financeiros IA dia 1 do mês às 07:00
+require('./jobs/receitaInsights').register();   // Insights receita IA dia 1 do mês às 07:00
 const { startAllJobs } = require('./jobs/index');
 const ProductionInitializer = require('./utils/productionInitializer');
 const TenantWhatsAppService = require('./services/TenantWhatsAppService');
@@ -444,6 +445,9 @@ class SaeeApp {
 
     // Relatório de No-Show (TDD 19) — view analítica, export CSV/PDF, insights Claude
     this.app.use('/api/relatorios/no-show', require('./routes/relatorios-no-show'));
+
+    // Relatório de Receita (TDD 20) — views analíticas, export CSV/PDF, insights Claude mensal
+    this.app.use('/api/relatorios/receita', require('./routes/relatorios-receita'));
 
     // IA Financeira (TDD 18) — score de risco, insights Claude, projeção de caixa, alertas
     this.app.use('/api/financeiro', require('./routes/ia-financeiro'));

--- a/src/jobs/receitaInsights.js
+++ b/src/jobs/receitaInsights.js
@@ -1,0 +1,136 @@
+/**
+ * receitaInsights.js — Job mensal de insights IA de receita
+ * Executa no dia 1 de cada mês às 07:00 (America/Sao_Paulo)
+ */
+const cron      = require('node-cron');
+const pool      = require('../database/postgres');
+const Anthropic = require('@anthropic-ai/sdk');
+const { schemaFromSlug }     = require('../services/CrmScoreService');
+const { buildReceitaPrompt } = require('../services/ReceitaPrompts');
+
+function decrementMes(mes) {
+  const [y, m] = mes.split('-').map(Number);
+  const d = new Date(y, m - 2, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+function anoAnteriorMes(mes) { return `${parseInt(mes.slice(0,4)) - 1}-${mes.slice(5)}`; }
+function mesAnterior() {
+  const d = new Date();
+  d.setMonth(d.getMonth() - 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+async function gerarInsightsTodos() {
+  const mes = mesAnterior();
+  const { rows: tenants } = await pool.query(
+    "SELECT id, slug FROM public.tenants WHERE status IN ('active','trial')"
+  ).catch(() => ({ rows: [] }));
+
+  for (const tenant of tenants) {
+    try {
+      const schema = schemaFromSlug(tenant.slug);
+
+      // Idempotência
+      const exist = await pool.query(
+        `SELECT id FROM "${schema}".ia_insights_financeiros_receita WHERE tenant_id = $1 AND mes = $2`,
+        [tenant.id, mes]
+      ).catch(() => ({ rows: [] }));
+      if (exist.rows.length) continue;
+
+      // Coletar dados
+      const mesAnt  = decrementMes(mes);
+      const mesAnoA = anoAnteriorMes(mes);
+
+      const [kpisRes, profRes, procRes, agingRes] = await Promise.all([
+        pool.query(`
+          WITH atual AS (
+            SELECT COALESCE(SUM(receita_bruta),0) AS receita_bruta, COALESCE(SUM(receita_liquida),0) AS receita_liquida,
+                   COALESCE(SUM(total_atendimentos),0) AS total_atendimentos, COALESCE(AVG(ticket_medio),0) AS ticket_medio
+            FROM "${schema}".vw_receita_mensal WHERE tenant_id = $1 AND mes = $2
+          ),
+          anterior AS (
+            SELECT COALESCE(SUM(receita_bruta),0) AS receita_bruta, COALESCE(SUM(total_atendimentos),0) AS total_atendimentos
+            FROM "${schema}".vw_receita_mensal WHERE tenant_id = $1 AND mes = $3
+          ),
+          ano_passado AS (SELECT COALESCE(SUM(receita_bruta),0) AS receita_bruta FROM "${schema}".vw_receita_mensal WHERE tenant_id = $1 AND mes = $4),
+          inadimplencia AS (
+            SELECT COUNT(*) AS total_faturas,
+                   SUM(CASE WHEN status IN ('aguardando','vencida') THEN 1 ELSE 0 END) AS faturas_em_atraso,
+                   ROUND(SUM(CASE WHEN status IN ('aguardando','vencida') THEN 1.0 ELSE 0 END)/NULLIF(COUNT(*),0)*100,1) AS taxa_inadimplencia_pct
+            FROM "${schema}".faturas WHERE tenant_id = $1 AND TO_CHAR(criado_em,'YYYY-MM') = $2
+          )
+          SELECT a.receita_bruta, a.receita_liquida, a.total_atendimentos, ROUND(a.ticket_medio::NUMERIC,2) AS ticket_medio,
+                 ROUND((a.receita_bruta-ant.receita_bruta)*100.0/NULLIF(ant.receita_bruta,0),1) AS var_mes_anterior_pct,
+                 ROUND((a.receita_bruta-ap.receita_bruta)*100.0/NULLIF(ap.receita_bruta,0),1) AS var_ano_anterior_pct,
+                 ROUND((a.total_atendimentos-ant.total_atendimentos)*100.0/NULLIF(ant.total_atendimentos,0),1) AS var_atendimentos_pct,
+                 i.taxa_inadimplencia_pct, i.faturas_em_atraso, i.total_faturas
+          FROM atual a, anterior ant, ano_passado ap, inadimplencia i
+        `, [tenant.id, mes, mesAnt, mesAnoA]),
+
+        pool.query(`
+          SELECT profissional_id, profissional_nome, SUM(total_atendimentos) AS total_atendimentos,
+                 ROUND(SUM(receita_bruta)::NUMERIC,2) AS receita_total, ROUND(AVG(ticket_medio)::NUMERIC,2) AS ticket_medio,
+                 ROUND((SUM(pct_do_total)/NULLIF(COUNT(*),0))::NUMERIC,1) AS pct_medio_do_total
+          FROM "${schema}".vw_receita_por_profissional WHERE tenant_id = $1 AND mes = $2
+          GROUP BY profissional_id, profissional_nome ORDER BY receita_total DESC LIMIT 5
+        `, [tenant.id, mes]),
+
+        pool.query(`
+          SELECT procedimento_id, procedimento_nome, SUM(quantidade) AS quantidade_total,
+                 ROUND(SUM(receita_total)::NUMERIC,2) AS receita_total, ROUND(AVG(ticket_medio)::NUMERIC,2) AS ticket_medio,
+                 ROUND(AVG(variacao_3_meses)::NUMERIC,2) AS variacao_3_meses
+          FROM "${schema}".vw_receita_por_procedimento WHERE tenant_id = $1 AND mes = $2
+          GROUP BY procedimento_id, procedimento_nome ORDER BY receita_total DESC LIMIT 10
+        `, [tenant.id, mes]),
+
+        pool.query(`
+          SELECT CASE WHEN (CURRENT_DATE-vencimento::DATE) BETWEEN 0 AND 30 THEN '0-30 dias'
+                      WHEN (CURRENT_DATE-vencimento::DATE) BETWEEN 31 AND 60 THEN '31-60 dias'
+                      WHEN (CURRENT_DATE-vencimento::DATE) BETWEEN 61 AND 90 THEN '61-90 dias'
+                      ELSE '90+ dias' END AS faixa_aging,
+                 COUNT(*) AS quantidade, ROUND(SUM(valor_liquido-valor_pago)::NUMERIC,2) AS valor_total
+          FROM "${schema}".faturas WHERE tenant_id = $1 AND status IN ('aguardando','vencida') AND vencimento < CURRENT_DATE
+          GROUP BY faixa_aging ORDER BY MIN(CURRENT_DATE-vencimento::DATE) ASC
+        `, [tenant.id]),
+      ]).catch(() => [{ rows: [{}] }, { rows: [] }, { rows: [] }, { rows: [] }]);
+
+      const dadosContexto = {
+        mes, kpis: kpisRes.rows[0] || {},
+        porProfissional: profRes.rows, porProcedimento: procRes.rows, aging: agingRes.rows,
+      };
+
+      const prompt = buildReceitaPrompt(dadosContexto);
+      const client = new Anthropic();
+      const msg = await client.messages.create({
+        model: 'claude-opus-4-5', max_tokens: 1200,
+        messages: [{ role: 'user', content: prompt }],
+      });
+      const texto  = msg.content[0].text;
+      const tokens = (msg.usage?.input_tokens || 0) + (msg.usage?.output_tokens || 0);
+
+      await pool.query(
+        `INSERT INTO "${schema}".ia_insights_financeiros_receita
+           (tenant_id, mes, texto_insight, dados_contexto, modelo_ia, tokens_usados)
+         VALUES ($1,$2,$3,$4,'claude-opus-4-5',$5)
+         ON CONFLICT (tenant_id, mes) DO UPDATE SET
+           texto_insight = EXCLUDED.texto_insight, dados_contexto = EXCLUDED.dados_contexto,
+           tokens_usados = EXCLUDED.tokens_usados, gerado_em = NOW()`,
+        [tenant.id, mes, texto, JSON.stringify(dadosContexto), tokens]
+      );
+      console.log(`[receitaInsights] ${tenant.slug}: insight ${mes} gerado (${tokens} tokens)`);
+    } catch (err) {
+      console.error(`[receitaInsights] Erro tenant ${tenant.slug}:`, err.message);
+    }
+  }
+}
+
+function register() {
+  cron.schedule('0 7 1 * *', () => {
+    gerarInsightsTodos().catch(err =>
+      console.error('[receitaInsights] Erro no job:', err.message)
+    );
+  }, { timezone: 'America/Sao_Paulo' });
+  console.log('[receitaInsights] Job registrado — 07:00 dia 1 do mês');
+}
+
+module.exports = { register, gerarInsightsTodos };

--- a/src/migrations/032_relatorio_receita.sql
+++ b/src/migrations/032_relatorio_receita.sql
@@ -1,0 +1,83 @@
+-- Migration 032: Relatório de Receita — views analíticas, insights IA, índices de performance
+
+-- View: vw_receita_mensal
+CREATE OR REPLACE VIEW "%%SCHEMA%%".vw_receita_mensal AS
+SELECT
+  f.tenant_id,
+  TO_CHAR(p.data_recebimento, 'YYYY-MM')              AS mes,
+  EXTRACT(YEAR FROM p.data_recebimento)::INTEGER       AS ano,
+  EXTRACT(MONTH FROM p.data_recebimento)::INTEGER      AS mes_num,
+  COUNT(DISTINCT f.id)                                 AS total_atendimentos,
+  COALESCE(SUM(p.valor), 0)                           AS receita_bruta,
+  COALESCE(SUM(p.valor) - SUM(COALESCE(f.valor_desconto, 0)), 0) AS receita_liquida,
+  AVG(p.valor)                                         AS ticket_medio,
+  p.forma                                              AS forma_pagamento
+FROM "%%SCHEMA%%".faturas f
+JOIN "%%SCHEMA%%".pagamentos p ON p.fatura_id = f.id
+WHERE f.status IN ('paga','parcial')
+GROUP BY f.tenant_id, TO_CHAR(p.data_recebimento, 'YYYY-MM'), p.forma;
+
+-- View: vw_receita_por_profissional
+CREATE OR REPLACE VIEW "%%SCHEMA%%".vw_receita_por_profissional AS
+SELECT
+  f.tenant_id,
+  f.profissional_id,
+  pr.nome                                               AS profissional_nome,
+  TO_CHAR(p.data_recebimento, 'YYYY-MM')               AS mes,
+  COUNT(DISTINCT f.id)                                  AS total_atendimentos,
+  COALESCE(SUM(p.valor), 0)                            AS receita_bruta,
+  AVG(p.valor)                                          AS ticket_medio,
+  SUM(p.valor) * 100.0 / NULLIF(SUM(SUM(p.valor)) OVER (
+    PARTITION BY f.tenant_id, TO_CHAR(p.data_recebimento, 'YYYY-MM')
+  ), 0)                                                 AS pct_do_total,
+  SUM(p.valor) * COALESCE(pr.percentual_repasse, 0) / 100.0 AS comissao_calculada
+FROM "%%SCHEMA%%".faturas f
+JOIN "%%SCHEMA%%".pagamentos p ON p.fatura_id = f.id
+JOIN "%%SCHEMA%%".profissionais pr ON pr.id = f.profissional_id AND pr.tenant_id = f.tenant_id
+WHERE f.status IN ('paga','parcial')
+GROUP BY f.tenant_id, f.profissional_id, pr.nome, TO_CHAR(p.data_recebimento, 'YYYY-MM');
+
+-- View: vw_receita_por_procedimento
+CREATE OR REPLACE VIEW "%%SCHEMA%%".vw_receita_por_procedimento AS
+SELECT
+  f.tenant_id,
+  fi.procedimento_id,
+  fi.descricao                                          AS procedimento_nome,
+  TO_CHAR(p.data_recebimento, 'YYYY-MM')               AS mes,
+  COUNT(*)                                              AS quantidade,
+  COALESCE(SUM(fi.subtotal), 0)                        AS receita_total,
+  AVG(fi.subtotal)                                      AS ticket_medio,
+  SUM(fi.subtotal) * 100.0 / NULLIF(SUM(SUM(fi.subtotal)) OVER (
+    PARTITION BY f.tenant_id, TO_CHAR(p.data_recebimento, 'YYYY-MM')
+  ), 0)                                                 AS pct_do_total,
+  SUM(fi.subtotal) - LAG(SUM(fi.subtotal), 3) OVER (
+    PARTITION BY f.tenant_id, fi.procedimento_id
+    ORDER BY TO_CHAR(p.data_recebimento, 'YYYY-MM')
+  )                                                     AS variacao_3_meses
+FROM "%%SCHEMA%%".faturas f
+JOIN "%%SCHEMA%%".pagamentos p ON p.fatura_id = f.id
+JOIN "%%SCHEMA%%".faturas_itens fi ON fi.fatura_id = f.id
+WHERE f.status IN ('paga','parcial')
+GROUP BY f.tenant_id, fi.procedimento_id, fi.descricao, TO_CHAR(p.data_recebimento, 'YYYY-MM');
+
+-- Tabela de insights IA financeiros de receita (separada da TDD18 para evitar conflito de UNIQUE)
+CREATE TABLE IF NOT EXISTS "%%SCHEMA%%".ia_insights_financeiros_receita (
+  id              BIGSERIAL PRIMARY KEY,
+  tenant_id       TEXT NOT NULL,
+  mes             TEXT NOT NULL,
+  texto_insight   TEXT NOT NULL,
+  dados_contexto  JSONB NOT NULL,
+  modelo_ia       TEXT NOT NULL DEFAULT 'claude-opus-4-5',
+  tokens_usados   INTEGER,
+  gerado_em       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  gerado_por_job  INTEGER NOT NULL DEFAULT 1,
+  UNIQUE(tenant_id, mes)
+);
+CREATE INDEX IF NOT EXISTS idx_ia_insights_receita_tenant_mes
+  ON "%%SCHEMA%%".ia_insights_financeiros_receita(tenant_id, mes DESC);
+
+-- Índices de performance
+CREATE INDEX IF NOT EXISTS idx_faturas_tenant_status_vencimento
+  ON "%%SCHEMA%%".faturas(tenant_id, status, vencimento);
+CREATE INDEX IF NOT EXISTS idx_pagamentos_data_receb
+  ON "%%SCHEMA%%".pagamentos(fatura_id, data_recebimento);

--- a/src/routes/relatorios-receita.js
+++ b/src/routes/relatorios-receita.js
@@ -1,0 +1,426 @@
+/**
+ * relatorios-receita.js — TDD 20: Relatório de Receita
+ * Endpoints: dashboard, por-procedimento, inadimplencia, insights, profissional/:id, export
+ */
+const express   = require('express');
+const router    = express.Router({ mergeParams: true });
+const pool      = require('../database/postgres');
+const Anthropic = require('@anthropic-ai/sdk');
+const { authenticateToken } = require('../middleware/auth');
+const { extractTenant }     = require('../middleware/tenant');
+const { schemaFromSlug }    = require('../services/CrmScoreService');
+const { buildReceitaPrompt } = require('../services/ReceitaPrompts');
+const { buildReceitaPDF }    = require('../services/ReceitaPDF');
+
+function getSchema(req) {
+  const slug = req.tenant?.slug || req.usuario?.tenant_slug;
+  return slug ? schemaFromSlug(slug) : null;
+}
+function getTenantId(req) {
+  return req.tenantId || req.tenant?.id || req.usuario?.tenant_id;
+}
+function getUser(req) { return req.usuario || req.user || {}; }
+const auth = [extractTenant, authenticateToken];
+
+function assertRole(...roles) {
+  return (req, res, next) => {
+    const perfil = getUser(req).perfil || getUser(req).role || 'admin';
+    if (!roles.includes(perfil)) return res.status(403).json({ success: false, message: 'Acesso negado' });
+    next();
+  };
+}
+
+// Helpers de período
+function decrementMes(mes) {
+  const [y, m] = mes.split('-').map(Number);
+  const d = new Date(y, m - 2, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+function anoAnteriorMes(mes) { return `${parseInt(mes.slice(0,4)) - 1}-${mes.slice(5)}`; }
+function mesAtual() { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}`; }
+
+// Queries dinâmicas com schema
+function SQL(schema) {
+  return {
+    KPIS_MES: `
+      WITH atual AS (
+        SELECT COALESCE(SUM(receita_bruta), 0) AS receita_bruta,
+               COALESCE(SUM(receita_liquida), 0) AS receita_liquida,
+               COALESCE(SUM(total_atendimentos), 0) AS total_atendimentos,
+               COALESCE(AVG(ticket_medio), 0) AS ticket_medio
+        FROM "${schema}".vw_receita_mensal WHERE tenant_id = $1 AND mes = $2
+      ),
+      anterior AS (
+        SELECT COALESCE(SUM(receita_bruta), 0) AS receita_bruta,
+               COALESCE(SUM(total_atendimentos), 0) AS total_atendimentos,
+               COALESCE(AVG(ticket_medio), 0) AS ticket_medio
+        FROM "${schema}".vw_receita_mensal WHERE tenant_id = $1 AND mes = $3
+      ),
+      ano_passado AS (
+        SELECT COALESCE(SUM(receita_bruta), 0) AS receita_bruta
+        FROM "${schema}".vw_receita_mensal WHERE tenant_id = $1 AND mes = $4
+      ),
+      inadimplencia AS (
+        SELECT COUNT(*) AS total_faturas,
+               SUM(CASE WHEN status IN ('aguardando','vencida') THEN 1 ELSE 0 END) AS faturas_em_atraso,
+               ROUND(SUM(CASE WHEN status IN ('aguardando','vencida') THEN 1.0 ELSE 0 END) / NULLIF(COUNT(*), 0) * 100, 1) AS taxa_inadimplencia_pct
+        FROM "${schema}".faturas WHERE tenant_id = $1 AND TO_CHAR(criado_em, 'YYYY-MM') = $2
+      )
+      SELECT a.receita_bruta, a.receita_liquida, a.total_atendimentos,
+             ROUND(a.ticket_medio::NUMERIC, 2) AS ticket_medio,
+             ROUND((a.receita_bruta - ant.receita_bruta) * 100.0 / NULLIF(ant.receita_bruta, 0), 1) AS var_mes_anterior_pct,
+             ROUND((a.receita_bruta - ap.receita_bruta) * 100.0 / NULLIF(ap.receita_bruta, 0), 1) AS var_ano_anterior_pct,
+             ROUND((a.total_atendimentos - ant.total_atendimentos) * 100.0 / NULLIF(ant.total_atendimentos, 0), 1) AS var_atendimentos_pct,
+             i.taxa_inadimplencia_pct, i.faturas_em_atraso, i.total_faturas
+      FROM atual a, anterior ant, ano_passado ap, inadimplencia i
+    `,
+    EVOLUCAO_12M: `
+      SELECT mes, SUM(receita_bruta) AS receita_bruta, SUM(receita_liquida) AS receita_liquida,
+             SUM(total_atendimentos) AS total_atendimentos,
+             ROUND(AVG(ticket_medio)::NUMERIC, 2) AS ticket_medio,
+             AVG(SUM(receita_bruta)) OVER (PARTITION BY tenant_id ORDER BY mes ROWS BETWEEN 11 PRECEDING AND CURRENT ROW) AS media_movel_12m
+      FROM "${schema}".vw_receita_mensal
+      WHERE tenant_id = $1 AND mes >= TO_CHAR(NOW() - INTERVAL '12 months', 'YYYY-MM')
+      GROUP BY tenant_id, mes ORDER BY mes ASC
+    `,
+    RANKING_PROF: `
+      SELECT profissional_id, profissional_nome,
+             SUM(total_atendimentos) AS total_atendimentos,
+             ROUND(SUM(receita_bruta)::NUMERIC, 2) AS receita_total,
+             ROUND(AVG(ticket_medio)::NUMERIC, 2) AS ticket_medio,
+             ROUND((SUM(pct_do_total) / NULLIF(COUNT(*), 0))::NUMERIC, 1) AS pct_medio_do_total,
+             ROUND(SUM(comissao_calculada)::NUMERIC, 2) AS comissao_total
+      FROM "${schema}".vw_receita_por_profissional
+      WHERE tenant_id = $1 AND mes BETWEEN $2 AND $3
+      GROUP BY profissional_id, profissional_nome ORDER BY receita_total DESC
+    `,
+    EVOLUCAO_PROF_6M: `
+      SELECT mes, profissional_id, profissional_nome,
+             ROUND(SUM(receita_bruta)::NUMERIC, 2) AS receita
+      FROM "${schema}".vw_receita_por_profissional
+      WHERE tenant_id = $1 AND mes >= TO_CHAR(NOW() - INTERVAL '6 months', 'YYYY-MM')
+      GROUP BY mes, profissional_id, profissional_nome ORDER BY mes ASC, receita DESC
+    `,
+    RANKING_PROC: `
+      SELECT procedimento_id, procedimento_nome,
+             SUM(quantidade) AS quantidade_total,
+             ROUND(SUM(receita_total)::NUMERIC, 2) AS receita_total,
+             ROUND(AVG(ticket_medio)::NUMERIC, 2) AS ticket_medio,
+             ROUND((SUM(pct_do_total) / NULLIF(COUNT(*), 0))::NUMERIC, 1) AS pct_medio_do_total,
+             ROUND(AVG(variacao_3_meses)::NUMERIC, 2) AS tendencia_3m
+      FROM "${schema}".vw_receita_por_procedimento
+      WHERE tenant_id = $1 AND mes BETWEEN $2 AND $3
+      GROUP BY procedimento_id, procedimento_nome ORDER BY receita_total DESC
+    `,
+    POR_FORMA_PAGAMENTO: `
+      SELECT forma_pagamento, SUM(receita_bruta) AS receita_total,
+             SUM(total_atendimentos) AS total_atendimentos,
+             ROUND((SUM(receita_bruta) * 100.0 / NULLIF(SUM(SUM(receita_bruta)) OVER (), 0))::NUMERIC, 1) AS pct_do_total
+      FROM "${schema}".vw_receita_mensal
+      WHERE tenant_id = $1 AND mes BETWEEN $2 AND $3
+      GROUP BY forma_pagamento ORDER BY receita_total DESC
+    `,
+    AGING: `
+      SELECT
+        CASE
+          WHEN (CURRENT_DATE - vencimento::DATE) BETWEEN 0 AND 30 THEN '0-30 dias'
+          WHEN (CURRENT_DATE - vencimento::DATE) BETWEEN 31 AND 60 THEN '31-60 dias'
+          WHEN (CURRENT_DATE - vencimento::DATE) BETWEEN 61 AND 90 THEN '61-90 dias'
+          ELSE '90+ dias'
+        END AS faixa_aging,
+        CASE
+          WHEN (CURRENT_DATE - vencimento::DATE) BETWEEN 0 AND 30 THEN 1
+          WHEN (CURRENT_DATE - vencimento::DATE) BETWEEN 31 AND 60 THEN 2
+          WHEN (CURRENT_DATE - vencimento::DATE) BETWEEN 61 AND 90 THEN 3
+          ELSE 4
+        END AS faixa_ordem,
+        COUNT(*) AS quantidade,
+        ROUND(SUM(valor_liquido - valor_pago)::NUMERIC, 2) AS valor_total,
+        ROUND(AVG(valor_liquido - valor_pago)::NUMERIC, 2) AS ticket_medio_inadimplente,
+        ROUND(AVG(CURRENT_DATE - vencimento::DATE)::NUMERIC, 0) AS dias_atraso_medio
+      FROM "${schema}".faturas
+      WHERE tenant_id = $1 AND status IN ('aguardando','vencida') AND vencimento < CURRENT_DATE
+      GROUP BY faixa_aging, faixa_ordem ORDER BY faixa_ordem ASC
+    `,
+    TOP_DEVEDORES: `
+      SELECT f.paciente_id, pac.nome AS paciente_nome, pac.telefone,
+             COUNT(*) AS faturas_em_aberto,
+             ROUND(SUM(f.valor_liquido - f.valor_pago)::NUMERIC, 2) AS valor_total_divida,
+             MIN(f.vencimento) AS fatura_mais_antiga,
+             MAX(f.vencimento) AS fatura_mais_recente
+      FROM "${schema}".faturas f
+      JOIN "${schema}".pacientes pac ON pac.id = f.paciente_id AND pac.tenant_id = f.tenant_id
+      WHERE f.tenant_id = $1 AND f.status IN ('aguardando','vencida') AND f.vencimento < CURRENT_DATE
+      GROUP BY f.paciente_id, pac.nome, pac.telefone
+      ORDER BY valor_total_divida DESC LIMIT 10
+    `,
+    SAZONALIDADE: `
+      SELECT
+        ((EXTRACT(DAY FROM p.data_recebimento)::INTEGER - 1) / 7 + 1) AS semana_do_mes,
+        EXTRACT(DOW FROM p.data_recebimento)::INTEGER AS dia_semana_num,
+        CASE EXTRACT(DOW FROM p.data_recebimento)::INTEGER
+          WHEN 0 THEN 'Dom' WHEN 1 THEN 'Seg' WHEN 2 THEN 'Ter'
+          WHEN 3 THEN 'Qua' WHEN 4 THEN 'Qui' WHEN 5 THEN 'Sex' WHEN 6 THEN 'Sab'
+        END AS dia_semana_nome,
+        ROUND(SUM(p.valor)::NUMERIC, 2) AS receita_total,
+        COUNT(*) AS total_atendimentos,
+        ROUND(AVG(p.valor)::NUMERIC, 2) AS ticket_medio_dia
+      FROM "${schema}".faturas f
+      JOIN "${schema}".pagamentos p ON p.fatura_id = f.id
+      WHERE f.tenant_id = $1 AND f.status IN ('paga','parcial')
+        AND p.data_recebimento BETWEEN $2::DATE AND $3::DATE
+      GROUP BY semana_do_mes, dia_semana_num, dia_semana_nome
+      ORDER BY semana_do_mes ASC, dia_semana_num ASC
+    `,
+    YOY: `
+      WITH atual AS (
+        SELECT mes, SUM(receita_bruta) AS receita
+        FROM "${schema}".vw_receita_mensal WHERE tenant_id = $1 AND mes BETWEEN $2 AND $3
+        GROUP BY mes
+      ),
+      ano_anterior AS (
+        SELECT TO_CHAR(TO_DATE(mes, 'YYYY-MM') + INTERVAL '1 year', 'YYYY-MM') AS mes_projetado,
+               SUM(receita_bruta) AS receita
+        FROM "${schema}".vw_receita_mensal WHERE tenant_id = $1
+          AND mes BETWEEN TO_CHAR(TO_DATE($2,'YYYY-MM') - INTERVAL '1 year','YYYY-MM')
+                      AND TO_CHAR(TO_DATE($3,'YYYY-MM') - INTERVAL '1 year','YYYY-MM')
+        GROUP BY mes
+      )
+      SELECT a.mes, ROUND(a.receita::NUMERIC, 2) AS receita_atual,
+             ROUND(COALESCE(aa.receita, 0)::NUMERIC, 2) AS receita_ano_anterior,
+             ROUND(((a.receita - COALESCE(aa.receita, 0)) * 100.0 / NULLIF(aa.receita, 0))::NUMERIC, 1) AS variacao_yoy_pct
+      FROM atual a LEFT JOIN ano_anterior aa ON aa.mes_projetado = a.mes
+      ORDER BY a.mes ASC
+    `,
+    VISAO_PROFISSIONAL: `
+      SELECT f.id, p.data_recebimento AS data_pagamento, pac.nome AS paciente_nome,
+             fi.descricao AS procedimento_nome, p.valor,
+             COALESCE(f.valor_desconto, 0) AS desconto,
+             f.valor_liquido, p.forma AS forma_pagamento, f.status,
+             ROUND((p.valor * COALESCE(pr.percentual_repasse, 0) / 100.0)::NUMERIC, 2) AS minha_comissao
+      FROM "${schema}".faturas f
+      JOIN "${schema}".pagamentos p ON p.fatura_id = f.id
+      JOIN "${schema}".pacientes pac ON pac.id = f.paciente_id AND pac.tenant_id = f.tenant_id
+      LEFT JOIN "${schema}".faturas_itens fi ON fi.fatura_id = f.id
+      JOIN "${schema}".profissionais pr ON pr.id = f.profissional_id AND pr.tenant_id = f.tenant_id
+      WHERE f.tenant_id = $1 AND f.profissional_id = $2
+        AND TO_CHAR(p.data_recebimento, 'YYYY-MM') BETWEEN $3 AND $4
+      ORDER BY p.data_recebimento DESC
+    `,
+    EXPORT_ROWS: `
+      SELECT p.data_recebimento AS data_pagamento, pac.nome AS paciente_nome,
+             pr.nome AS profissional_nome, fi.descricao AS procedimento_nome,
+             p.valor, COALESCE(f.valor_desconto, 0) AS desconto,
+             f.valor_liquido, p.forma AS forma_pagamento, f.status
+      FROM "${schema}".faturas f
+      JOIN "${schema}".pagamentos p ON p.fatura_id = f.id
+      JOIN "${schema}".pacientes pac ON pac.id = f.paciente_id AND pac.tenant_id = f.tenant_id
+      JOIN "${schema}".profissionais pr ON pr.id = f.profissional_id AND pr.tenant_id = f.tenant_id
+      LEFT JOIN "${schema}".faturas_itens fi ON fi.fatura_id = f.id
+      WHERE f.tenant_id = $1 AND TO_CHAR(p.data_recebimento, 'YYYY-MM') BETWEEN $2 AND $3
+      ORDER BY p.data_recebimento DESC LIMIT 5000
+    `,
+  };
+}
+
+// ── GET / — dashboard principal ───────────────────────────────────────────────
+router.get('/', ...auth, async (req, res) => {
+  try {
+    const schema   = getSchema(req);
+    const tenantId = getTenantId(req);
+    const inicio   = req.query.inicio || mesAtual();
+    const fim      = req.query.fim    || mesAtual();
+    const sql      = SQL(schema);
+    const mesAnt   = decrementMes(inicio);
+    const mesAnoA  = anoAnteriorMes(inicio);
+
+    // Cache check
+    const cacheKey = `receita_${inicio}_${fim}`;
+    const { rows: cached } = await pool.query(
+      `SELECT dados_json FROM "${schema}".relatorio_cache
+       WHERE tenant_id = $1 AND tipo = $2 AND expira_em > NOW() LIMIT 1`,
+      [tenantId, cacheKey]
+    ).catch(() => ({ rows: [] }));
+    if (cached.length) {
+      return res.json({ success: true, data: JSON.parse(cached[0].dados_json), fonte: 'cache' });
+    }
+
+    const [kpisRes, evolRes, profRes, evolProfRes, procRes, formaRes, agingRes, devedRes, sazonRes, yoyRes] =
+      await Promise.all([
+        pool.query(sql.KPIS_MES,           [tenantId, inicio, mesAnt, mesAnoA]),
+        pool.query(sql.EVOLUCAO_12M,        [tenantId]),
+        pool.query(sql.RANKING_PROF,        [tenantId, inicio, fim]),
+        pool.query(sql.EVOLUCAO_PROF_6M,    [tenantId]),
+        pool.query(sql.RANKING_PROC,        [tenantId, inicio, fim]),
+        pool.query(sql.POR_FORMA_PAGAMENTO, [tenantId, inicio, fim]),
+        pool.query(sql.AGING,               [tenantId]),
+        pool.query(sql.TOP_DEVEDORES,       [tenantId]),
+        pool.query(sql.SAZONALIDADE,        [tenantId, `${inicio}-01`, `${fim}-31`]),
+        pool.query(sql.YOY,                 [tenantId, inicio, fim]),
+      ]);
+
+    const data = {
+      kpis: kpisRes.rows[0] || {},
+      evolucao: evolRes.rows,
+      porProfissional: profRes.rows,
+      evolucaoProfissional: evolProfRes.rows,
+      porProcedimento: procRes.rows,
+      porFormaPagamento: formaRes.rows,
+      aging: agingRes.rows,
+      topDevedores: devedRes.rows,
+      sazonalidade: sazonRes.rows,
+      yoy: yoyRes.rows,
+    };
+
+    // Salvar cache 1h
+    await pool.query(
+      `INSERT INTO "${schema}".relatorio_cache (tenant_id, tipo, chave, dados_json, expira_em)
+       VALUES ($1,$2,$3,$4,NOW() + INTERVAL '1 hour')
+       ON CONFLICT (tenant_id, tipo, chave) DO UPDATE
+         SET dados_json = EXCLUDED.dados_json, gerado_em = NOW(), expira_em = EXCLUDED.expira_em`,
+      [tenantId, cacheKey, cacheKey, JSON.stringify(data)]
+    ).catch(() => {});
+
+    res.json({ success: true, data, fonte: 'db' });
+  } catch (err) {
+    console.error('[Receita] Erro:', err.message);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// ── GET /por-procedimento ──────────────────────────────────────────────────────
+router.get('/por-procedimento', ...auth, async (req, res) => {
+  try {
+    const schema   = getSchema(req);
+    const tenantId = getTenantId(req);
+    const inicio   = req.query.inicio || mesAtual();
+    const fim      = req.query.fim    || mesAtual();
+    const { rows } = await pool.query(SQL(schema).RANKING_PROC, [tenantId, inicio, fim]);
+    res.json({ success: true, data: rows });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// ── GET /inadimplencia ────────────────────────────────────────────────────────
+router.get('/inadimplencia', ...auth, async (req, res) => {
+  try {
+    const schema   = getSchema(req);
+    const tenantId = getTenantId(req);
+    const sql      = SQL(schema);
+    const [agingRes, devedRes] = await Promise.all([
+      pool.query(sql.AGING, [tenantId]),
+      pool.query(sql.TOP_DEVEDORES, [tenantId]),
+    ]);
+    res.json({ success: true, data: { aging: agingRes.rows, topDevedores: devedRes.rows } });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// ── GET /insights ─────────────────────────────────────────────────────────────
+router.get('/insights', ...auth, async (req, res) => {
+  try {
+    const schema   = getSchema(req);
+    const tenantId = getTenantId(req);
+    const mes      = req.query.mes || mesAtual();
+    const { rows } = await pool.query(
+      `SELECT texto_insight, dados_contexto, gerado_em, modelo_ia, tokens_usados
+       FROM "${schema}".ia_insights_financeiros_receita
+       WHERE tenant_id = $1 AND mes = $2`,
+      [tenantId, mes]
+    );
+    if (!rows.length) {
+      return res.status(202).json({
+        success: false,
+        message: 'Insights ainda sendo gerados. Disponível a partir do 1º do mês às 07:00.',
+        retry_after: 60,
+      });
+    }
+    res.json({ success: true, data: rows[0] });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// ── GET /profissional/:id ─────────────────────────────────────────────────────
+router.get('/profissional/:id', ...auth, async (req, res) => {
+  try {
+    const schema   = getSchema(req);
+    const tenantId = getTenantId(req);
+    const usuario  = getUser(req);
+    const profId   = Number(req.params.id);
+    if (usuario.perfil === 'profissional' && usuario.profissional_id !== profId) {
+      return res.status(403).json({ success: false, message: 'Acesso negado' });
+    }
+    const inicio = req.query.inicio || mesAtual();
+    const fim    = req.query.fim    || mesAtual();
+    const { rows } = await pool.query(SQL(schema).VISAO_PROFISSIONAL, [tenantId, profId, inicio, fim]);
+    res.json({ success: true, data: rows });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// ── GET /export ───────────────────────────────────────────────────────────────
+router.get('/export', ...auth, async (req, res) => {
+  try {
+    const schema   = getSchema(req);
+    const tenantId = getTenantId(req);
+    const inicio   = req.query.inicio || mesAtual();
+    const fim      = req.query.fim    || mesAtual();
+    const formato  = req.query.formato || 'csv';
+    const sql      = SQL(schema);
+    const { rows } = await pool.query(sql.EXPORT_ROWS, [tenantId, inicio, fim]);
+
+    if (formato === 'csv') {
+      const { Parser } = require('json2csv');
+      const fields = [
+        { label: 'Data Pagamento',  value: 'data_pagamento' },
+        { label: 'Paciente',        value: 'paciente_nome' },
+        { label: 'Profissional',    value: 'profissional_nome' },
+        { label: 'Procedimento',    value: 'procedimento_nome' },
+        { label: 'Valor (R$)',      value: 'valor' },
+        { label: 'Desconto (R$)',   value: 'desconto' },
+        { label: 'Líquido (R$)',    value: 'valor_liquido' },
+        { label: 'Forma Pagamento', value: 'forma_pagamento' },
+        { label: 'Status',          value: 'status' },
+      ];
+      const parser = new Parser({ fields, delimiter: ';', withBOM: true });
+      const csv = parser.parse(rows);
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+      res.setHeader('Content-Disposition', `attachment; filename="receita-${inicio}-${fim}.csv"`);
+      return res.send(csv);
+    }
+
+    if (formato === 'pdf') {
+      const mesAnt  = decrementMes(inicio);
+      const mesAnoA = anoAnteriorMes(inicio);
+      const [kpisRes, profRes, procRes, agingRes] = await Promise.all([
+        pool.query(sql.KPIS_MES,    [tenantId, inicio, mesAnt, mesAnoA]),
+        pool.query(sql.RANKING_PROF,[tenantId, inicio, fim]),
+        pool.query(sql.RANKING_PROC,[tenantId, inicio, fim]),
+        pool.query(sql.AGING,       [tenantId]),
+      ]);
+      const PDFDocument = require('pdfkit');
+      const doc = new PDFDocument({ margin: 50, size: 'A4' });
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', `attachment; filename="receita-${inicio}-${fim}.pdf"`);
+      doc.pipe(res);
+      buildReceitaPDF(doc, {
+        rows, kpis: kpisRes.rows[0] || {},
+        porProfissional: profRes.rows, porProcedimento: procRes.rows,
+        aging: agingRes.rows, inicio, fim,
+      });
+      doc.end();
+      return;
+    }
+
+    res.status(400).json({ success: false, message: 'formato deve ser csv ou pdf' });
+  } catch (err) {
+    console.error('[Receita/Export] Erro:', err.message);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/services/ReceitaPDF.js
+++ b/src/services/ReceitaPDF.js
@@ -1,0 +1,147 @@
+/**
+ * ReceitaPDF — geração de PDF do relatório de receita via pdfkit
+ */
+
+function renderTableHeader(doc, headers, colWidths, startX) {
+  let x = startX;
+  doc.fontSize(9).font('Helvetica-Bold');
+  headers.forEach((h, i) => {
+    doc.text(h, x, doc.y, { width: colWidths[i], continued: i < headers.length - 1 });
+    x += colWidths[i];
+  });
+  doc.moveDown(0.3);
+  doc.moveTo(startX, doc.y).lineTo(startX + colWidths.reduce((a, b) => a + b, 0), doc.y).stroke();
+  doc.moveDown(0.2);
+}
+
+function renderTableRow(doc, cols, colWidths, startX) {
+  if (doc.y > 700) doc.addPage();
+  let x = startX;
+  doc.font('Helvetica').fontSize(8);
+  cols.forEach((c, i) => {
+    doc.text(String(c ?? ''), x, doc.y, {
+      width: colWidths[i],
+      continued: i < cols.length - 1,
+      ellipsis: true,
+    });
+    x += colWidths[i];
+  });
+  doc.moveDown(0.4);
+}
+
+function buildReceitaPDF(doc, { rows, kpis, porProfissional, porProcedimento, aging, inicio, fim }) {
+  const logoPath = process.env.TENANT_LOGO_PATH;
+
+  if (logoPath) {
+    try { doc.image(logoPath, 50, 45, { width: 80 }); } catch { /* logo opcional */ }
+  }
+  doc.fontSize(16).font('Helvetica-Bold')
+     .text('Relatório de Receita', 150, 50, { align: 'center' });
+  doc.fontSize(10).font('Helvetica')
+     .text(`Período: ${inicio} a ${fim}`, { align: 'center' });
+  doc.moveDown(2);
+
+  // KPIs
+  doc.fontSize(12).font('Helvetica-Bold').text('Indicadores do Período');
+  doc.moveDown(0.5);
+  const kpiRows = [
+    ['Receita bruta',           `R$ ${kpis.receita_bruta ?? 0}`],
+    ['Receita líquida',         `R$ ${kpis.receita_liquida ?? 0}`],
+    ['Ticket médio',            `R$ ${kpis.ticket_medio ?? 0}`],
+    ['Total de atendimentos',   kpis.total_atendimentos ?? 0],
+    ['Variação vs. mês anterior', `${parseFloat(kpis.var_mes_anterior_pct || 0) > 0 ? '+' : ''}${kpis.var_mes_anterior_pct ?? 0}%`],
+    ['Variação vs. ano anterior', `${parseFloat(kpis.var_ano_anterior_pct || 0) > 0 ? '+' : ''}${kpis.var_ano_anterior_pct ?? 0}%`],
+    ['Taxa de inadimplência',   `${kpis.taxa_inadimplencia_pct ?? 0}%`],
+    ['Faturas em atraso',       `${kpis.faturas_em_atraso ?? 0} de ${kpis.total_faturas ?? 0}`],
+  ];
+  kpiRows.forEach(([label, valor]) => {
+    doc.fontSize(10).font('Helvetica-Bold').text(label + ': ', { continued: true })
+       .font('Helvetica').text(String(valor));
+  });
+  doc.moveDown(1.5);
+
+  // Ranking de Profissionais
+  if (porProfissional && porProfissional.length > 0) {
+    doc.fontSize(12).font('Helvetica-Bold').text('Receita por Profissional');
+    doc.moveDown(0.5);
+    const profHeaders  = ['Profissional', 'Atendimentos', 'Receita (R$)', 'Ticket Médio', '% Total'];
+    const profWidths   = [150, 80, 90, 90, 60];
+    renderTableHeader(doc, profHeaders, profWidths, 50);
+    porProfissional.slice(0, 10).forEach(p => {
+      renderTableRow(doc, [
+        p.profissional_nome,
+        p.total_atendimentos,
+        p.receita_total,
+        p.ticket_medio,
+        `${p.pct_medio_do_total}%`,
+      ], profWidths, 50);
+    });
+    doc.moveDown(1);
+  }
+
+  // Ranking de Procedimentos
+  if (porProcedimento && porProcedimento.length > 0) {
+    if (doc.y > 600) doc.addPage();
+    doc.fontSize(12).font('Helvetica-Bold').text('Receita por Procedimento');
+    doc.moveDown(0.5);
+    const procHeaders = ['Procedimento', 'Qtd', 'Receita (R$)', 'Ticket Médio', 'Tendência 3m'];
+    const procWidths  = [160, 40, 90, 90, 90];
+    renderTableHeader(doc, procHeaders, procWidths, 50);
+    porProcedimento.slice(0, 10).forEach(p => {
+      renderTableRow(doc, [
+        p.procedimento_nome,
+        p.quantidade_total,
+        p.receita_total,
+        p.ticket_medio,
+        p.tendencia_3m != null ? `R$ ${p.tendencia_3m}` : 'N/D',
+      ], procWidths, 50);
+    });
+    doc.moveDown(1);
+  }
+
+  // Inadimplência por faixa
+  if (aging && aging.length > 0) {
+    if (doc.y > 600) doc.addPage();
+    doc.fontSize(12).font('Helvetica-Bold').text('Inadimplência por Faixa de Atraso');
+    doc.moveDown(0.5);
+    const agingHeaders = ['Faixa', 'Qtd Faturas', 'Valor Total (R$)', 'Ticket Médio', 'Dias Atraso Médio'];
+    const agingWidths  = [90, 80, 110, 110, 105];
+    renderTableHeader(doc, agingHeaders, agingWidths, 50);
+    aging.forEach(a => {
+      renderTableRow(doc, [
+        a.faixa_aging,
+        a.quantidade,
+        a.valor_total,
+        a.ticket_medio_inadimplente,
+        a.dias_atraso_medio,
+      ], agingWidths, 50);
+    });
+    doc.moveDown(1);
+  }
+
+  // Detalhamento de pagamentos
+  if (rows && rows.length > 0) {
+    if (doc.y > 550) doc.addPage();
+    doc.fontSize(12).font('Helvetica-Bold').text('Detalhamento de Pagamentos');
+    doc.moveDown(0.5);
+    const detHeaders = ['Data', 'Paciente', 'Profissional', 'Procedimento', 'Valor (R$)', 'Forma'];
+    const detWidths  = [60, 110, 100, 110, 70, 55];
+    renderTableHeader(doc, detHeaders, detWidths, 25);
+    rows.slice(0, 50).forEach(r => {
+      renderTableRow(doc, [
+        r.data_pagamento ? String(r.data_pagamento).slice(0, 10) : '',
+        r.paciente_nome,
+        r.profissional_nome,
+        r.procedimento_nome,
+        r.valor,
+        r.forma_pagamento,
+      ], detWidths, 25);
+    });
+    if (rows.length > 50) {
+      doc.moveDown(0.5).fontSize(8)
+         .text(`... e mais ${rows.length - 50} registros. Exporte em CSV para a listagem completa.`);
+    }
+  }
+}
+
+module.exports = { buildReceitaPDF };

--- a/src/services/ReceitaPrompts.js
+++ b/src/services/ReceitaPrompts.js
@@ -1,0 +1,37 @@
+/**
+ * ReceitaPrompts — prompts para insights financeiros de receita via Claude
+ */
+
+function buildReceitaPrompt({ kpis, porProfissional, porProcedimento, aging, mes }) {
+  const topProc     = [...porProcedimento].sort((a, b) => b.receita_total - a.receita_total)[0];
+  const procEmQueda = porProcedimento.find(p => parseFloat(p.variacao_3_meses) < -500);
+  const faixa90Mais = aging.find(a => a.faixa_aging === '90+ dias');
+
+  return `Você é um consultor financeiro especializado em clínicas médicas. Analise os dados de receita do mês ${mes} e gere um relatório executivo em linguagem natural, objetivo e acionável. Use no máximo 400 palavras. Estruture em:
+1) Situação geral (1 parágrafo — receita, crescimento, comparativo)
+2) Destaques positivos (1-2 itens com dados concretos)
+3) Alertas e riscos (1-3 itens — inadimplência, queda, ticket médio)
+4) Oportunidades para o próximo mês (2 itens com estimativa de receita em R$)
+
+DADOS FINANCEIROS DE ${mes}:
+- Receita bruta: R$ ${kpis.receita_bruta} (${parseFloat(kpis.var_mes_anterior_pct||0) > 0 ? '+' : ''}${kpis.var_mes_anterior_pct}% vs. mês anterior; ${parseFloat(kpis.var_ano_anterior_pct||0) > 0 ? '+' : ''}${kpis.var_ano_anterior_pct}% vs. ano anterior)
+- Receita líquida: R$ ${kpis.receita_liquida}
+- Ticket médio: R$ ${kpis.ticket_medio}
+- Total de atendimentos: ${kpis.total_atendimentos} (${parseFloat(kpis.var_atendimentos_pct||0) > 0 ? '+' : ''}${kpis.var_atendimentos_pct}% vs. mês anterior)
+- Taxa de inadimplência: ${kpis.taxa_inadimplencia_pct}% (${kpis.faturas_em_atraso} faturas em atraso de ${kpis.total_faturas} emitidas)
+${faixa90Mais ? `- Dívidas acima de 90 dias: R$ ${faixa90Mais.valor_total} (${faixa90Mais.quantidade} faturas)` : '- Sem dívidas acima de 90 dias'}
+
+PROFISSIONAIS — TOP 3:
+${porProfissional.slice(0, 3).map((p, i) => `${i+1}. ${p.profissional_nome}: R$ ${p.receita_total} (${p.total_atendimentos} atend., ticket médio R$ ${p.ticket_medio}, ${p.pct_medio_do_total}% da receita total)`).join('\n')}
+
+PROCEDIMENTOS:
+- Maior receita: ${topProc?.procedimento_nome || 'N/D'} — R$ ${topProc?.receita_total || 0} (${topProc?.quantidade_total || 0} realizados)
+${procEmQueda ? `- Em queda: ${procEmQueda.procedimento_nome} (queda de R$ ${Math.abs(procEmQueda.variacao_3_meses)})` : '- Sem procedimentos em queda significativa'}
+
+INADIMPLÊNCIA POR FAIXA:
+${aging.map(a => `- ${a.faixa_aging}: ${a.quantidade} faturas | R$ ${a.valor_total}`).join('\n')}
+
+Seja específico com os números. Responda em português brasileiro.`;
+}
+
+module.exports = { buildReceitaPrompt };


### PR DESCRIPTION
Closes #TDD20

## O que foi feito
- Migration `032_relatorio_receita.sql`: 3 views (vw_receita_mensal, vw_receita_por_profissional, vw_receita_por_procedimento) + tabela ia_insights_financeiros_receita
- `ReceitaPrompts.js`: builder de prompt estruturado para Claude
- `ReceitaPDF.js`: geração de PDF com KPIs, ranking profissionais, aging, procedimentos
- `relatorios-receita.js`: 6 endpoints (dashboard, por-procedimento, inadimplência, insights, /profissional/:id, export CSV/PDF) com cache 1h
- `receitaInsights.js`: cron mensal (dia 1, 07:00) para insights com claude-opus-4-5
- `app.js`: rota e job registrados

## Adaptações PostgreSQL
- Views usam JOIN pagamentos para data_recebimento/forma (campos não existem em faturas)
- criado_em no lugar de data_emissao, vencimento no lugar de data_vencimento
- Status aguardando/vencida (não pendente)
- Tabela de insights separada (ia_insights_financeiros_receita) para evitar conflito com TDD 18

## Testado em
Branch feature/relatorios-receita-tdd20

🤖 Generated with [Claude Code](https://claude.com/claude-code)