### PR TITLE
feat: Dashboard Principal com IA Proativa — cache KPIs, alertas socket.io, briefing (TDD21)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -58,6 +58,9 @@ require('./jobs/qrExpirar').register();         // Expirar QR codes vencidos (1m
 require('./jobs/iaScores').register();          // Scores de risco financeiro IA às 06:00 diário
 require('./jobs/iaInsights').register();        // Insights financeiros IA dia 1 do mês às 07:00
 require('./jobs/receitaInsights').register();   // Insights receita IA dia 1 do mês às 07:00
+require('./jobs/dashboard-cache').register();   // Pré-cálculo KPIs dashboard IA a cada hora
+require('./jobs/briefing-diario').register();   // Briefing IA diário às 07:00
+require('./jobs/alertas-engine').register();    // Detectores de alertas proativos a cada 5min
 const { startAllJobs } = require('./jobs/index');
 const ProductionInitializer = require('./utils/productionInitializer');
 const TenantWhatsAppService = require('./services/TenantWhatsAppService');
@@ -448,6 +451,9 @@ class SaeeApp {
 
     // Relatório de Receita (TDD 20) — views analíticas, export CSV/PDF, insights Claude mensal
     this.app.use('/api/relatorios/receita', require('./routes/relatorios-receita'));
+
+    // Dashboard IA com alertas proativos e briefing (TDD 21)
+    this.app.use('/api/dashboard-ia', require('./routes/dashboard-ia'));
 
     // IA Financeira (TDD 18) — score de risco, insights Claude, projeção de caixa, alertas
     this.app.use('/api/financeiro', require('./routes/ia-financeiro'));

--- a/src/jobs/alertas-engine.js
+++ b/src/jobs/alertas-engine.js
@@ -1,0 +1,34 @@
+/**
+ * alertas-engine.js — Job a cada 5 minutos para detectar alertas proativos
+ * Cron: */5 * * * *
+ */
+const cron = require('node-cron');
+const pool = require('../database/postgres');
+const { schemaFromSlug } = require('../services/CrmScoreService');
+const { detectarAlertas } = require('../services/alertas-detectores');
+
+async function executar() {
+  const { rows: tenants } = await pool.query(
+    "SELECT id, slug FROM public.tenants WHERE status IN ('active','trial')"
+  ).catch(() => ({ rows: [] }));
+
+  for (const tenant of tenants) {
+    try {
+      const schema = schemaFromSlug(tenant.slug);
+      await detectarAlertas(pool, tenant.id, schema);
+    } catch (err) {
+      console.error(`[Alertas Engine] Erro tenant ${tenant.slug}:`, err.message);
+    }
+  }
+}
+
+function register() {
+  cron.schedule('*/5 * * * *', () => {
+    executar().catch(err =>
+      console.error('[Alertas Engine] Erro no job:', err.message)
+    );
+  }, { timezone: 'America/Sao_Paulo' });
+  console.log('[Alertas Engine] Job registrado — a cada 5 minutos');
+}
+
+module.exports = { register, executar };

--- a/src/jobs/briefing-diario.js
+++ b/src/jobs/briefing-diario.js
@@ -1,0 +1,173 @@
+/**
+ * briefing-diario.js — Job diário às 7h para gerar briefing IA por tenant/perfil
+ * Cron: 0 7 * * *
+ */
+const cron = require('node-cron');
+const pool = require('../database/postgres');
+const { schemaFromSlug } = require('../services/CrmScoreService');
+const { buildBriefingPrompt } = require('../services/briefing-prompts');
+
+const PERFIS = ['admin', 'financeiro', 'recepcionista'];
+
+async function gerarKpisBasicos(tenantId, schema, perfil) {
+  const hoje     = new Date().toISOString().slice(0, 10);
+  const mesAtual = hoje.slice(0, 7);
+  let kpis = { perfil };
+
+  try {
+    if (perfil === 'admin') {
+      const [agRes, recRes, inadRes, metaRes] = await Promise.all([
+        pool.query(
+          `SELECT COUNT(*) AS total,
+                  COUNT(*) FILTER (WHERE status = 'confirmado') AS confirmados,
+                  COUNT(*) FILTER (WHERE status = 'no_show') AS no_shows
+           FROM "${schema}".agendamentos_lite
+           WHERE tenant_id = $1 AND data = $2`,
+          [tenantId, hoje]
+        ).catch(() => ({ rows: [{ total: 0, confirmados: 0, no_shows: 0 }] })),
+        pool.query(
+          `SELECT COALESCE(SUM(valor),0) AS receita_mes
+           FROM "${schema}".faturas
+           WHERE tenant_id = $1 AND status = 'pago' AND to_char(criado_em,'YYYY-MM') = $2`,
+          [tenantId, mesAtual]
+        ).catch(() => ({ rows: [{ receita_mes: 0 }] })),
+        pool.query(
+          `SELECT COALESCE(SUM(valor),0) AS inadimplencia_valor
+           FROM "${schema}".faturas
+           WHERE tenant_id = $1 AND status = 'vencida'`,
+          [tenantId]
+        ).catch(() => ({ rows: [{ inadimplencia_valor: 0 }] })),
+        pool.query(
+          `SELECT valor_meta FROM "${schema}".metas_dashboard
+           WHERE tenant_id = $1 AND tipo = 'receita' AND mes = $2`,
+          [tenantId, mesAtual]
+        ).catch(() => ({ rows: [] }))
+      ]);
+      kpis = {
+        ...kpis,
+        agendamentos_hoje: parseInt(agRes.rows[0]?.total || 0),
+        confirmados: parseInt(agRes.rows[0]?.confirmados || 0),
+        no_shows: parseInt(agRes.rows[0]?.no_shows || 0),
+        receita_mes: parseFloat(recRes.rows[0]?.receita_mes || 0),
+        meta_receita: parseFloat(metaRes.rows[0]?.valor_meta || 0),
+        inadimplencia_valor: parseFloat(inadRes.rows[0]?.inadimplencia_valor || 0),
+        alertas_criticos: 0
+      };
+    } else if (perfil === 'financeiro') {
+      const [recRes, inadRes, metaRes] = await Promise.all([
+        pool.query(
+          `SELECT COALESCE(SUM(valor),0) AS receita_mes
+           FROM "${schema}".faturas
+           WHERE tenant_id = $1 AND status = 'pago' AND to_char(criado_em,'YYYY-MM') = $2`,
+          [tenantId, mesAtual]
+        ).catch(() => ({ rows: [{ receita_mes: 0 }] })),
+        pool.query(
+          `SELECT COALESCE(SUM(valor),0) AS valor_vencido,
+                  COUNT(*) AS faturas_vencidas
+           FROM "${schema}".faturas
+           WHERE tenant_id = $1 AND status = 'vencida'`,
+          [tenantId]
+        ).catch(() => ({ rows: [{ valor_vencido: 0, faturas_vencidas: 0 }] })),
+        pool.query(
+          `SELECT valor_meta FROM "${schema}".metas_dashboard
+           WHERE tenant_id = $1 AND tipo = 'receita' AND mes = $2`,
+          [tenantId, mesAtual]
+        ).catch(() => ({ rows: [] }))
+      ]);
+      kpis = {
+        ...kpis,
+        receita_mes: parseFloat(recRes.rows[0]?.receita_mes || 0),
+        meta_receita: parseFloat(metaRes.rows[0]?.valor_meta || 0),
+        faturas_vencidas: parseInt(inadRes.rows[0]?.faturas_vencidas || 0),
+        valor_vencido: parseFloat(inadRes.rows[0]?.valor_vencido || 0),
+        cobradas_hoje: 0
+      };
+    } else if (perfil === 'recepcionista') {
+      const [agRes, filaRes] = await Promise.all([
+        pool.query(
+          `SELECT COUNT(*) AS total,
+                  COUNT(*) FILTER (WHERE status IN ('agendado','pendente')) AS aguardando
+           FROM "${schema}".agendamentos_lite
+           WHERE tenant_id = $1 AND data = $2`,
+          [tenantId, hoje]
+        ).catch(() => ({ rows: [{ total: 0, aguardando: 0 }] })),
+        pool.query(
+          `SELECT COUNT(*) AS fila
+           FROM "${schema}".fila_espera
+           WHERE tenant_id = $1 AND status = 'aguardando'`,
+          [tenantId]
+        ).catch(() => ({ rows: [{ fila: 0 }] }))
+      ]);
+      kpis = {
+        ...kpis,
+        agendamentos_hoje: parseInt(agRes.rows[0]?.total || 0),
+        aguardando_confirmacao: parseInt(agRes.rows[0]?.aguardando || 0),
+        checkins_pendentes: 0,
+        fila_atual: parseInt(filaRes.rows[0]?.fila || 0)
+      };
+    }
+  } catch (err) {
+    console.error(`[Briefing] Erro KPIs ${tenantId}/${perfil}:`, err.message);
+  }
+  return kpis;
+}
+
+async function gerarBriefingTenant(tenant) {
+  const schema = schemaFromSlug(tenant.slug);
+
+  // Get clinic name
+  const nomeClinica = tenant.nome || 'AltClinic';
+
+  const Anthropic = require('@anthropic-ai/sdk');
+  const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+  for (const perfil of PERFIS) {
+    try {
+      const kpis = await gerarKpisBasicos(tenant.id, schema, perfil);
+      const prompt = buildBriefingPrompt(kpis, perfil, nomeClinica);
+
+      const message = await client.messages.create({
+        model: 'claude-sonnet-4-6',
+        max_tokens: 512,
+        messages: [{ role: 'user', content: prompt }]
+      });
+      const texto = message.content[0]?.text || '';
+      const resultado = { briefing: texto, kpis, gerado_em: new Date().toISOString() };
+
+      await pool.query(
+        `INSERT INTO "${schema}".dashboard_cache
+           (tenant_id, perfil, contexto_id, tipo, dados_json, expira_em)
+         VALUES ($1,$2,NULL,'briefing',$3, NOW() + INTERVAL '23 hours')
+         ON CONFLICT (tenant_id, perfil, contexto_id, tipo)
+         DO UPDATE SET dados_json=$3, calculado_em=NOW(), expira_em=NOW() + INTERVAL '23 hours'`,
+        [tenant.id, perfil, JSON.stringify(resultado)]
+      ).catch(() => {});
+
+      console.log(`[Briefing] ${tenant.slug}/${perfil}: gerado (${texto.length} chars)`);
+    } catch (err) {
+      console.error(`[Briefing] Erro ${tenant.slug}/${perfil}:`, err.message);
+    }
+  }
+}
+
+async function executar() {
+  const { rows: tenants } = await pool.query(
+    "SELECT id, slug, nome FROM public.tenants WHERE status IN ('active','trial')"
+  ).catch(() => ({ rows: [] }));
+
+  for (const tenant of tenants) {
+    await gerarBriefingTenant(tenant);
+  }
+  console.log(`[Briefing Diário] Concluído — ${tenants.length} tenant(s)`);
+}
+
+function register() {
+  cron.schedule('0 7 * * *', () => {
+    executar().catch(err =>
+      console.error('[Briefing Diário] Erro no job:', err.message)
+    );
+  }, { timezone: 'America/Sao_Paulo' });
+  console.log('[Briefing Diário] Job registrado — 07:00 diário');
+}
+
+module.exports = { register, executar };

--- a/src/jobs/dashboard-cache.js
+++ b/src/jobs/dashboard-cache.js
@@ -1,0 +1,110 @@
+/**
+ * dashboard-cache.js — Job horário de pré-cálculo de KPIs para o dashboard IA
+ * Cron: 0 * * * * (a cada hora, no início da hora)
+ */
+const cron = require('node-cron');
+const pool = require('../database/postgres');
+const { schemaFromSlug } = require('../services/CrmScoreService');
+
+const PERFIS = ['admin', 'financeiro', 'recepcionista'];
+
+async function calcularECacheKpis(tenantId, schema, perfil) {
+  const hoje     = new Date().toISOString().slice(0, 10);
+  const mesAtual = hoje.slice(0, 7);
+
+  let kpis = { perfil, calculado_em: new Date().toISOString() };
+
+  try {
+    if (perfil === 'admin' || perfil === 'financeiro') {
+      const [agRes, recRes, inadRes] = await Promise.all([
+        pool.query(
+          `SELECT COUNT(*) AS total,
+                  COUNT(*) FILTER (WHERE status = 'no_show') AS no_shows
+           FROM "${schema}".agendamentos_lite
+           WHERE tenant_id = $1 AND data = $2`,
+          [tenantId, hoje]
+        ).catch(() => ({ rows: [{ total: 0, no_shows: 0 }] })),
+        pool.query(
+          `SELECT COALESCE(SUM(valor),0) AS receita_mes
+           FROM "${schema}".faturas
+           WHERE tenant_id = $1 AND status = 'pago'
+             AND to_char(criado_em,'YYYY-MM') = $2`,
+          [tenantId, mesAtual]
+        ).catch(() => ({ rows: [{ receita_mes: 0 }] })),
+        pool.query(
+          `SELECT COALESCE(SUM(valor),0) AS inadimplencia, COUNT(*) AS vencidas
+           FROM "${schema}".faturas
+           WHERE tenant_id = $1 AND status = 'vencida'`,
+          [tenantId]
+        ).catch(() => ({ rows: [{ inadimplencia: 0, vencidas: 0 }] }))
+      ]);
+      kpis = {
+        ...kpis,
+        agendamentos_hoje: parseInt(agRes.rows[0]?.total || 0),
+        no_shows: parseInt(agRes.rows[0]?.no_shows || 0),
+        receita_mes: parseFloat(recRes.rows[0]?.receita_mes || 0),
+        inadimplencia_valor: parseFloat(inadRes.rows[0]?.inadimplencia || 0),
+        faturas_vencidas: parseInt(inadRes.rows[0]?.vencidas || 0),
+      };
+    } else if (perfil === 'recepcionista') {
+      const [agRes, filaRes] = await Promise.all([
+        pool.query(
+          `SELECT COUNT(*) AS total,
+                  COUNT(*) FILTER (WHERE status IN ('agendado','pendente')) AS aguardando
+           FROM "${schema}".agendamentos_lite
+           WHERE tenant_id = $1 AND data = $2`,
+          [tenantId, hoje]
+        ).catch(() => ({ rows: [{ total: 0, aguardando: 0 }] })),
+        pool.query(
+          `SELECT COUNT(*) AS fila
+           FROM "${schema}".fila_espera
+           WHERE tenant_id = $1 AND status = 'aguardando'`,
+          [tenantId]
+        ).catch(() => ({ rows: [{ fila: 0 }] }))
+      ]);
+      kpis = {
+        ...kpis,
+        agendamentos_hoje: parseInt(agRes.rows[0]?.total || 0),
+        aguardando_confirmacao: parseInt(agRes.rows[0]?.aguardando || 0),
+        fila_atual: parseInt(filaRes.rows[0]?.fila || 0),
+      };
+    }
+
+    await pool.query(
+      `INSERT INTO "${schema}".dashboard_cache
+         (tenant_id, perfil, contexto_id, tipo, dados_json, expira_em)
+       VALUES ($1,$2,NULL,'kpis',$3, NOW() + INTERVAL '65 minutes')
+       ON CONFLICT (tenant_id, perfil, contexto_id, tipo)
+       DO UPDATE SET dados_json=$3, calculado_em=NOW(), expira_em=NOW() + INTERVAL '65 minutes'`,
+      [tenantId, perfil, JSON.stringify(kpis)]
+    ).catch(() => {});
+  } catch (err) {
+    console.error(`[Dashboard Cache] Erro tenant ${tenantId} perfil ${perfil}:`, err.message);
+  }
+}
+
+async function executar() {
+  const { rows: tenants } = await pool.query(
+    "SELECT id, slug FROM public.tenants WHERE status IN ('active','trial')"
+  ).catch(() => ({ rows: [] }));
+
+  for (const tenant of tenants) {
+    const schema = schemaFromSlug(tenant.slug);
+    for (const perfil of PERFIS) {
+      await calcularECacheKpis(tenant.id, schema, perfil);
+    }
+    if (tenants.length > 1) console.log(`[Dashboard Cache] ${tenant.slug}: KPIs calculados`);
+  }
+  console.log(`[Dashboard Cache] Ciclo concluído — ${tenants.length} tenant(s)`);
+}
+
+function register() {
+  cron.schedule('0 * * * *', () => {
+    executar().catch(err =>
+      console.error('[Dashboard Cache] Erro no job:', err.message)
+    );
+  }, { timezone: 'America/Sao_Paulo' });
+  console.log('[Dashboard Cache] Job registrado — a cada hora');
+}
+
+module.exports = { register, executar };

--- a/src/migrations/033_dashboard_ia.sql
+++ b/src/migrations/033_dashboard_ia.sql
@@ -1,0 +1,79 @@
+-- Migration 033: Dashboard IA — cache, alertas, config e metas
+-- Placeholder %%SCHEMA%% será substituído pelo runner de migrations
+
+CREATE TABLE IF NOT EXISTS %%SCHEMA%%.dashboard_cache (
+  id           BIGSERIAL PRIMARY KEY,
+  tenant_id    TEXT        NOT NULL,
+  perfil       TEXT        NOT NULL,
+  contexto_id  TEXT,
+  tipo         TEXT        NOT NULL,
+  dados_json   JSONB       NOT NULL,
+  calculado_em TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expira_em    TIMESTAMPTZ NOT NULL,
+  UNIQUE(tenant_id, perfil, contexto_id, tipo)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dash_cache_lookup
+  ON %%SCHEMA%%.dashboard_cache(tenant_id, perfil, contexto_id, tipo, expira_em);
+
+CREATE INDEX IF NOT EXISTS idx_dashcache_tenant_tipo_expira
+  ON %%SCHEMA%%.dashboard_cache(tenant_id, tipo, expira_em);
+
+CREATE TABLE IF NOT EXISTS %%SCHEMA%%.alertas_proativos (
+  id            BIGSERIAL PRIMARY KEY,
+  tenant_id     TEXT        NOT NULL,
+  usuario_id    INTEGER,
+  perfil_alvo   TEXT,
+  tipo          TEXT        NOT NULL,
+  prioridade    TEXT        NOT NULL DEFAULT 'normal'
+                  CHECK (prioridade IN ('baixa','normal','alta','critica')),
+  titulo        TEXT        NOT NULL,
+  mensagem      TEXT        NOT NULL,
+  dados_json    JSONB,
+  acao_url      TEXT,
+  lido          BOOLEAN     NOT NULL DEFAULT false,
+  criado_em     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  lido_em       TIMESTAMPTZ,
+  expira_em     TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_alertas_tenant_usuario
+  ON %%SCHEMA%%.alertas_proativos(tenant_id, usuario_id, lido, criado_em DESC);
+
+CREATE INDEX IF NOT EXISTS idx_alertas_tenant_perfil
+  ON %%SCHEMA%%.alertas_proativos(tenant_id, perfil_alvo, lido, criado_em DESC);
+
+CREATE INDEX IF NOT EXISTS idx_alertas_tenant_tipo_criado
+  ON %%SCHEMA%%.alertas_proativos(tenant_id, tipo, criado_em DESC);
+
+CREATE TABLE IF NOT EXISTS %%SCHEMA%%.dashboard_config (
+  id                  BIGSERIAL PRIMARY KEY,
+  usuario_id          INTEGER     NOT NULL UNIQUE,
+  tenant_id           TEXT        NOT NULL,
+  layout_json         JSONB       NOT NULL DEFAULT '{}',
+  alertas_config_json JSONB       NOT NULL DEFAULT '{}',
+  horario_briefing    TEXT        NOT NULL DEFAULT '07:00',
+  atualizado_em       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_dash_config_tenant
+  ON %%SCHEMA%%.dashboard_config(tenant_id, usuario_id);
+
+CREATE TABLE IF NOT EXISTS %%SCHEMA%%.metas_dashboard (
+  id          BIGSERIAL PRIMARY KEY,
+  tenant_id   TEXT           NOT NULL,
+  tipo        TEXT           NOT NULL
+                CHECK (tipo IN ('receita','atendimentos','no_show_max','inadimplencia_max')),
+  valor_meta  NUMERIC(10,2)  NOT NULL,
+  mes         TEXT           NOT NULL,
+  criado_por  INTEGER        NOT NULL,
+  criado_em   TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+  UNIQUE(tenant_id, tipo, mes)
+);
+
+CREATE INDEX IF NOT EXISTS idx_metas_tenant_mes
+  ON %%SCHEMA%%.metas_dashboard(tenant_id, mes);
+
+-- Index for agendamentos_lite used by KPI engine
+CREATE INDEX IF NOT EXISTS idx_agl_tenant_data_status
+  ON %%SCHEMA%%.agendamentos_lite(tenant_id, data, status);

--- a/src/routes/dashboard-ia.js
+++ b/src/routes/dashboard-ia.js
@@ -1,0 +1,533 @@
+/**
+ * dashboard-ia.js — Dashboard Principal com IA Proativa (TDD 21)
+ * Mount: /api/dashboard-ia
+ */
+const express = require('express');
+const router = express.Router();
+const pool    = require('../database/postgres');
+const { authenticateToken } = require('../middleware/auth');
+const { extractTenant }     = require('../middleware/tenant');
+const { schemaFromSlug }    = require('../services/CrmScoreService');
+
+const auth = [extractTenant, authenticateToken];
+
+function getSchema(req) {
+  const slug = req.tenant?.slug || req.usuario?.tenant_slug;
+  return slug ? schemaFromSlug(slug) : null;
+}
+function getTenantId(req) {
+  return req.tenantId || req.tenant?.id || req.usuario?.tenant_id;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// KPI calculators por perfil
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function calcularKpisAdmin(tenantId, schema) {
+  const hoje = new Date().toISOString().slice(0, 10);
+  const mesAtual = hoje.slice(0, 7);
+
+  const [agRes, recRes, inadRes, noShowRes, metaRes] = await Promise.all([
+    pool.query(
+      `SELECT
+         COUNT(*) AS total,
+         COUNT(*) FILTER (WHERE status IN ('confirmado')) AS confirmados,
+         COUNT(*) FILTER (WHERE status = 'no_show') AS no_shows
+       FROM "${schema}".agendamentos_lite
+       WHERE tenant_id = $1 AND data = $2`,
+      [tenantId, hoje]
+    ).catch(() => ({ rows: [{ total: 0, confirmados: 0, no_shows: 0 }] })),
+
+    pool.query(
+      `SELECT COALESCE(SUM(f.valor), 0) AS receita_mes
+       FROM "${schema}".faturas f
+       WHERE f.tenant_id = $1
+         AND f.status = 'pago'
+         AND to_char(f.criado_em, 'YYYY-MM') = $2`,
+      [tenantId, mesAtual]
+    ).catch(() => ({ rows: [{ receita_mes: 0 }] })),
+
+    pool.query(
+      `SELECT COALESCE(SUM(valor), 0) AS inadimplencia_valor,
+              COUNT(*) AS faturas_vencidas
+       FROM "${schema}".faturas
+       WHERE tenant_id = $1 AND status = 'vencida'`,
+      [tenantId]
+    ).catch(() => ({ rows: [{ inadimplencia_valor: 0, faturas_vencidas: 0 }] })),
+
+    pool.query(
+      `SELECT
+         COUNT(*) AS total,
+         COUNT(*) FILTER (WHERE status = 'no_show') AS no_shows
+       FROM "${schema}".agendamentos_lite
+       WHERE tenant_id = $1
+         AND to_char(data::date, 'YYYY-MM') = $2
+         AND status IN ('realizado','no_show','cancelado')`,
+      [tenantId, mesAtual]
+    ).catch(() => ({ rows: [{ total: 0, no_shows: 0 }] })),
+
+    pool.query(
+      `SELECT tipo, valor_meta
+       FROM "${schema}".metas_dashboard
+       WHERE tenant_id = $1 AND mes = $2`,
+      [tenantId, mesAtual]
+    ).catch(() => ({ rows: [] }))
+  ]);
+
+  const metas = {};
+  (metaRes.rows || []).forEach(m => { metas[m.tipo] = parseFloat(m.valor_meta); });
+
+  const totalMes = parseInt(noShowRes.rows[0]?.total || 0);
+  const noShowMes = parseInt(noShowRes.rows[0]?.no_shows || 0);
+
+  return {
+    perfil: 'admin',
+    agendamentos_hoje: parseInt(agRes.rows[0]?.total || 0),
+    confirmados: parseInt(agRes.rows[0]?.confirmados || 0),
+    no_shows: parseInt(agRes.rows[0]?.no_shows || 0),
+    receita_mes: parseFloat(recRes.rows[0]?.receita_mes || 0),
+    meta_receita: metas.receita || 0,
+    inadimplencia_valor: parseFloat(inadRes.rows[0]?.inadimplencia_valor || 0),
+    faturas_vencidas: parseInt(inadRes.rows[0]?.faturas_vencidas || 0),
+    taxa_no_show_mes: totalMes > 0 ? Math.round((noShowMes / totalMes) * 100) : 0,
+    metas,
+    calculado_em: new Date().toISOString()
+  };
+}
+
+async function calcularKpisMedico(tenantId, schema, usuarioId) {
+  const hoje = new Date().toISOString().slice(0, 10);
+
+  const { rows } = await pool.query(
+    `SELECT
+       COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE tipo = 'primeira_consulta') AS primeira_consulta,
+       COUNT(*) FILTER (WHERE tipo = 'retorno') AS retornos,
+       AVG(duracao_min) AS duracao_media_min
+     FROM "${schema}".agendamentos_lite
+     WHERE tenant_id = $1
+       AND profissional_id = $2
+       AND data = $3
+       AND status NOT IN ('cancelado')`,
+    [tenantId, usuarioId, hoje]
+  ).catch(() => ({ rows: [{ total: 0, primeira_consulta: 0, retornos: 0, duracao_media_min: 0 }] }));
+
+  return {
+    perfil: 'medico',
+    pacientes_hoje: parseInt(rows[0]?.total || 0),
+    primeira_consulta: parseInt(rows[0]?.primeira_consulta || 0),
+    retornos: parseInt(rows[0]?.retornos || 0),
+    duracao_media_min: Math.round(parseFloat(rows[0]?.duracao_media_min || 30)),
+    calculado_em: new Date().toISOString()
+  };
+}
+
+async function calcularKpisRecepcionista(tenantId, schema) {
+  const hoje = new Date().toISOString().slice(0, 10);
+
+  const [agRes, filaRes] = await Promise.all([
+    pool.query(
+      `SELECT
+         COUNT(*) AS total,
+         COUNT(*) FILTER (WHERE status IN ('agendado','pendente')) AS aguardando_confirmacao,
+         COUNT(*) FILTER (WHERE status = 'check_in') AS checkins_pendentes
+       FROM "${schema}".agendamentos_lite
+       WHERE tenant_id = $1 AND data = $2`,
+      [tenantId, hoje]
+    ).catch(() => ({ rows: [{ total: 0, aguardando_confirmacao: 0, checkins_pendentes: 0 }] })),
+
+    pool.query(
+      `SELECT COUNT(*) AS fila_atual
+       FROM "${schema}".fila_espera
+       WHERE tenant_id = $1 AND status = 'aguardando'`,
+      [tenantId]
+    ).catch(() => ({ rows: [{ fila_atual: 0 }] }))
+  ]);
+
+  return {
+    perfil: 'recepcionista',
+    agendamentos_hoje: parseInt(agRes.rows[0]?.total || 0),
+    aguardando_confirmacao: parseInt(agRes.rows[0]?.aguardando_confirmacao || 0),
+    checkins_pendentes: parseInt(agRes.rows[0]?.checkins_pendentes || 0),
+    fila_atual: parseInt(filaRes.rows[0]?.fila_atual || 0),
+    calculado_em: new Date().toISOString()
+  };
+}
+
+async function calcularKpisFinanceiro(tenantId, schema) {
+  const mesAtual = new Date().toISOString().slice(0, 7);
+  const hoje = new Date().toISOString().slice(0, 10);
+
+  const [recRes, inadRes, cobrancaRes, metaRes] = await Promise.all([
+    pool.query(
+      `SELECT COALESCE(SUM(valor), 0) AS receita_mes
+       FROM "${schema}".faturas
+       WHERE tenant_id = $1
+         AND status = 'pago'
+         AND to_char(criado_em, 'YYYY-MM') = $2`,
+      [tenantId, mesAtual]
+    ).catch(() => ({ rows: [{ receita_mes: 0 }] })),
+
+    pool.query(
+      `SELECT COUNT(*) AS faturas_vencidas,
+              COALESCE(SUM(valor), 0) AS valor_vencido
+       FROM "${schema}".faturas
+       WHERE tenant_id = $1 AND status = 'vencida'`,
+      [tenantId]
+    ).catch(() => ({ rows: [{ faturas_vencidas: 0, valor_vencido: 0 }] })),
+
+    pool.query(
+      `SELECT COUNT(*) AS cobradas_hoje
+       FROM "${schema}".cobrancas_whatsapp
+       WHERE tenant_id = $1 AND enviado_em::date = $2`,
+      [tenantId, hoje]
+    ).catch(() => ({ rows: [{ cobradas_hoje: 0 }] })),
+
+    pool.query(
+      `SELECT valor_meta FROM "${schema}".metas_dashboard
+       WHERE tenant_id = $1 AND tipo = 'receita' AND mes = $2`,
+      [tenantId, mesAtual]
+    ).catch(() => ({ rows: [] }))
+  ]);
+
+  return {
+    perfil: 'financeiro',
+    receita_mes: parseFloat(recRes.rows[0]?.receita_mes || 0),
+    meta_receita: parseFloat(metaRes.rows[0]?.valor_meta || 0),
+    faturas_vencidas: parseInt(inadRes.rows[0]?.faturas_vencidas || 0),
+    valor_vencido: parseFloat(inadRes.rows[0]?.valor_vencido || 0),
+    cobradas_hoje: parseInt(cobrancaRes.rows[0]?.cobradas_hoje || 0),
+    calculado_em: new Date().toISOString()
+  };
+}
+
+async function calcularKpisPorPerfil(tenantId, schema, perfil, usuarioId) {
+  switch (perfil) {
+    case 'admin':      return calcularKpisAdmin(tenantId, schema);
+    case 'medico':     return calcularKpisMedico(tenantId, schema, usuarioId);
+    case 'recepcionista': return calcularKpisRecepcionista(tenantId, schema);
+    case 'financeiro': return calcularKpisFinanceiro(tenantId, schema);
+    default:           return calcularKpisAdmin(tenantId, schema);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/dashboard-ia — KPIs (cache-first)
+// ─────────────────────────────────────────────────────────────────────────────
+router.get('/', auth, async (req, res) => {
+  const tenantId = getTenantId(req);
+  const schema   = getSchema(req);
+  if (!schema) return res.status(400).json({ success: false, message: 'Tenant inválido' });
+
+  const perfil     = req.usuario.perfil || 'admin';
+  const usuarioId  = req.usuario.id;
+  const contextoId = perfil === 'medico' ? String(usuarioId) : null;
+
+  try {
+    // Try cache
+    const cacheRes = await pool.query(
+      `SELECT dados_json FROM "${schema}".dashboard_cache
+       WHERE tenant_id = $1 AND perfil = $2 AND tipo = 'kpis'
+         AND (contexto_id = $3 OR (contexto_id IS NULL AND $3 IS NULL))
+         AND expira_em > NOW()
+       ORDER BY calculado_em DESC LIMIT 1`,
+      [tenantId, perfil, contextoId]
+    ).catch(() => ({ rows: [] }));
+
+    if (cacheRes.rows.length > 0) {
+      return res.json({ success: true, data: cacheRes.rows[0].dados_json, fromCache: true });
+    }
+
+    // Calculate fresh
+    const kpis = await calcularKpisPorPerfil(tenantId, schema, perfil, usuarioId);
+
+    // Store in cache (TTL 5 min)
+    await pool.query(
+      `INSERT INTO "${schema}".dashboard_cache
+         (tenant_id, perfil, contexto_id, tipo, dados_json, expira_em)
+       VALUES ($1,$2,$3,'kpis',$4, NOW() + INTERVAL '5 minutes')
+       ON CONFLICT (tenant_id, perfil, contexto_id, tipo)
+       DO UPDATE SET dados_json=$4, calculado_em=NOW(), expira_em=NOW() + INTERVAL '5 minutes'`,
+      [tenantId, perfil, contextoId, JSON.stringify(kpis)]
+    ).catch(() => {});
+
+    res.json({ success: true, data: kpis, fromCache: false });
+  } catch (err) {
+    console.error('[Dashboard IA] GET /:', err.message);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/dashboard-ia/briefing — briefing IA do dia
+// ─────────────────────────────────────────────────────────────────────────────
+router.get('/briefing', auth, async (req, res) => {
+  const tenantId = getTenantId(req);
+  const schema   = getSchema(req);
+  if (!schema) return res.status(400).json({ success: false, message: 'Tenant inválido' });
+
+  const perfil    = req.usuario.perfil || 'admin';
+  const usuarioId = req.usuario.id;
+
+  try {
+    // Try cache (TTL 1h for briefing)
+    const cacheRes = await pool.query(
+      `SELECT dados_json FROM "${schema}".dashboard_cache
+       WHERE tenant_id = $1 AND perfil = $2 AND tipo = 'briefing'
+         AND expira_em > NOW()
+       ORDER BY calculado_em DESC LIMIT 1`,
+      [tenantId, perfil]
+    ).catch(() => ({ rows: [] }));
+
+    if (cacheRes.rows.length > 0) {
+      return res.json({ success: true, data: cacheRes.rows[0].dados_json, fromCache: true });
+    }
+
+    // Get KPIs
+    const kpis = await calcularKpisPorPerfil(tenantId, schema, perfil, usuarioId);
+
+    // Get clinic name
+    const tenantRes = await pool.query(
+      'SELECT nome FROM public.tenants WHERE id = $1',
+      [tenantId]
+    ).catch(() => ({ rows: [{ nome: 'AltClinic' }] }));
+    const nomeClinica = tenantRes.rows[0]?.nome || 'AltClinic';
+
+    // Build prompt + call Claude
+    const { buildBriefingPrompt } = require('../services/briefing-prompts');
+    const prompt = buildBriefingPrompt(kpis, perfil, nomeClinica);
+
+    const Anthropic = require('@anthropic-ai/sdk');
+    const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+    const message = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 512,
+      messages: [{ role: 'user', content: prompt }]
+    });
+    const texto = message.content[0]?.text || '';
+
+    const resultado = { briefing: texto, kpis, gerado_em: new Date().toISOString() };
+
+    // Cache 1h
+    await pool.query(
+      `INSERT INTO "${schema}".dashboard_cache
+         (tenant_id, perfil, contexto_id, tipo, dados_json, expira_em)
+       VALUES ($1,$2,NULL,'briefing',$3, NOW() + INTERVAL '1 hour')
+       ON CONFLICT (tenant_id, perfil, contexto_id, tipo)
+       DO UPDATE SET dados_json=$3, calculado_em=NOW(), expira_em=NOW() + INTERVAL '1 hour'`,
+      [tenantId, perfil, JSON.stringify(resultado)]
+    ).catch(() => {});
+
+    res.json({ success: true, data: resultado });
+  } catch (err) {
+    console.error('[Dashboard IA] GET /briefing:', err.message);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/dashboard-ia/alertas — listar alertas do usuário
+// ─────────────────────────────────────────────────────────────────────────────
+router.get('/alertas', auth, async (req, res) => {
+  const tenantId = getTenantId(req);
+  const schema   = getSchema(req);
+  if (!schema) return res.status(400).json({ success: false, message: 'Tenant inválido' });
+
+  const usuarioId = req.usuario.id;
+  const perfil    = req.usuario.perfil || 'admin';
+  const { lido = 'false', limit = 20 } = req.query;
+
+  try {
+    const { rows } = await pool.query(
+      `SELECT * FROM "${schema}".alertas_proativos
+       WHERE tenant_id = $1
+         AND (usuario_id = $2 OR perfil_alvo = $3 OR perfil_alvo IS NULL)
+         AND ($4::boolean IS NULL OR lido = $4)
+         AND (expira_em IS NULL OR expira_em > NOW())
+       ORDER BY criado_em DESC
+       LIMIT $5`,
+      [tenantId, usuarioId, perfil,
+       lido === 'all' ? null : lido === 'true',
+       Math.min(parseInt(limit) || 20, 100)]
+    );
+    res.json({ success: true, data: rows });
+  } catch (err) {
+    console.error('[Dashboard IA] GET /alertas:', err.message);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PUT /api/dashboard-ia/alertas/:id/lido
+// ─────────────────────────────────────────────────────────────────────────────
+router.put('/alertas/:id/lido', auth, async (req, res) => {
+  const tenantId = getTenantId(req);
+  const schema   = getSchema(req);
+  if (!schema) return res.status(400).json({ success: false, message: 'Tenant inválido' });
+
+  const { id } = req.params;
+  try {
+    const { rows } = await pool.query(
+      `UPDATE "${schema}".alertas_proativos
+       SET lido = true, lido_em = NOW()
+       WHERE id = $1 AND tenant_id = $2
+       RETURNING *`,
+      [id, tenantId]
+    );
+    if (!rows.length) return res.status(404).json({ success: false, message: 'Alerta não encontrado' });
+    res.json({ success: true, data: rows[0] });
+  } catch (err) {
+    console.error('[Dashboard IA] PUT /alertas/:id/lido:', err.message);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/dashboard-ia/config
+// ─────────────────────────────────────────────────────────────────────────────
+router.get('/config', auth, async (req, res) => {
+  const tenantId  = getTenantId(req);
+  const schema    = getSchema(req);
+  const usuarioId = req.usuario.id;
+  if (!schema) return res.status(400).json({ success: false, message: 'Tenant inválido' });
+
+  try {
+    const { rows } = await pool.query(
+      `SELECT * FROM "${schema}".dashboard_config WHERE usuario_id = $1 AND tenant_id = $2`,
+      [usuarioId, tenantId]
+    );
+    if (!rows.length) {
+      return res.json({ success: true, data: {
+        usuario_id: usuarioId, tenant_id: tenantId,
+        layout_json: {}, alertas_config_json: {}, horario_briefing: '07:00'
+      }});
+    }
+    res.json({ success: true, data: rows[0] });
+  } catch (err) {
+    console.error('[Dashboard IA] GET /config:', err.message);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PUT /api/dashboard-ia/config
+// ─────────────────────────────────────────────────────────────────────────────
+router.put('/config', auth, async (req, res) => {
+  const tenantId  = getTenantId(req);
+  const schema    = getSchema(req);
+  const usuarioId = req.usuario.id;
+  if (!schema) return res.status(400).json({ success: false, message: 'Tenant inválido' });
+
+  const { layout_json, alertas_config_json, horario_briefing } = req.body;
+
+  try {
+    const { rows } = await pool.query(
+      `INSERT INTO "${schema}".dashboard_config
+         (usuario_id, tenant_id, layout_json, alertas_config_json, horario_briefing, atualizado_em)
+       VALUES ($1,$2,$3,$4,$5,NOW())
+       ON CONFLICT (usuario_id)
+       DO UPDATE SET
+         layout_json         = COALESCE($3, dashboard_config.layout_json),
+         alertas_config_json = COALESCE($4, dashboard_config.alertas_config_json),
+         horario_briefing    = COALESCE($5, dashboard_config.horario_briefing),
+         atualizado_em       = NOW()
+       RETURNING *`,
+      [usuarioId, tenantId,
+       layout_json ? JSON.stringify(layout_json) : '{}',
+       alertas_config_json ? JSON.stringify(alertas_config_json) : '{}',
+       horario_briefing || '07:00']
+    );
+    res.json({ success: true, data: rows[0] });
+  } catch (err) {
+    console.error('[Dashboard IA] PUT /config:', err.message);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/dashboard-ia/metas
+// ─────────────────────────────────────────────────────────────────────────────
+router.get('/metas', auth, async (req, res) => {
+  const tenantId = getTenantId(req);
+  const schema   = getSchema(req);
+  if (!schema) return res.status(400).json({ success: false, message: 'Tenant inválido' });
+
+  const { mes } = req.query;
+  const mesParam = mes || new Date().toISOString().slice(0, 7);
+
+  try {
+    const { rows } = await pool.query(
+      `SELECT * FROM "${schema}".metas_dashboard
+       WHERE tenant_id = $1 AND mes = $2
+       ORDER BY tipo`,
+      [tenantId, mesParam]
+    );
+    res.json({ success: true, data: rows });
+  } catch (err) {
+    console.error('[Dashboard IA] GET /metas:', err.message);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/dashboard-ia/metas — criar/upsert meta
+// ─────────────────────────────────────────────────────────────────────────────
+router.post('/metas', auth, async (req, res) => {
+  const tenantId  = getTenantId(req);
+  const schema    = getSchema(req);
+  const usuarioId = req.usuario.id;
+  const perfil    = req.usuario.perfil;
+  if (!schema) return res.status(400).json({ success: false, message: 'Tenant inválido' });
+  if (!['admin','financeiro'].includes(perfil)) {
+    return res.status(403).json({ success: false, message: 'Sem permissão' });
+  }
+
+  const { tipo, valor_meta, mes } = req.body;
+  if (!tipo || valor_meta == null || !mes) {
+    return res.status(400).json({ success: false, message: 'tipo, valor_meta e mes são obrigatórios' });
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `INSERT INTO "${schema}".metas_dashboard
+         (tenant_id, tipo, valor_meta, mes, criado_por)
+       VALUES ($1,$2,$3,$4,$5)
+       ON CONFLICT (tenant_id, tipo, mes)
+       DO UPDATE SET valor_meta = $3
+       RETURNING *`,
+      [tenantId, tipo, valor_meta, mes, usuarioId]
+    );
+    res.status(201).json({ success: true, data: rows[0] });
+  } catch (err) {
+    console.error('[Dashboard IA] POST /metas:', err.message);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DELETE /api/dashboard-ia/metas/:id
+// ─────────────────────────────────────────────────────────────────────────────
+router.delete('/metas/:id', auth, async (req, res) => {
+  const tenantId = getTenantId(req);
+  const schema   = getSchema(req);
+  const perfil   = req.usuario.perfil;
+  if (!schema) return res.status(400).json({ success: false, message: 'Tenant inválido' });
+  if (!['admin','financeiro'].includes(perfil)) {
+    return res.status(403).json({ success: false, message: 'Sem permissão' });
+  }
+
+  const { id } = req.params;
+  try {
+    const { rows } = await pool.query(
+      `DELETE FROM "${schema}".metas_dashboard WHERE id = $1 AND tenant_id = $2 RETURNING id`,
+      [id, tenantId]
+    );
+    if (!rows.length) return res.status(404).json({ success: false, message: 'Meta não encontrada' });
+    res.json({ success: true, message: 'Meta removida' });
+  } catch (err) {
+    console.error('[Dashboard IA] DELETE /metas/:id:', err.message);
+    res.status(500).json({ success: false, message: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/services/alertas-detectores.js
+++ b/src/services/alertas-detectores.js
@@ -1,0 +1,423 @@
+/**
+ * alertas-detectores.js — 12 detectores de alertas proativos para o dashboard IA
+ * detectarAlertas(pool, tenantId, schema) — chamado pelo job alertas-engine a cada 5min
+ */
+const { emitirAlertaInstantaneo } = require('../websocket/alertas');
+
+function getHoje() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function getAmanha() {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+// ── Detector 1: Agendamentos sem confirmação (D-1) ────────────────────────────
+async function detectarSemConfirmacao(pool, tenantId, schema) {
+  try {
+    const amanha = getAmanha();
+    const { rows } = await pool.query(
+      `SELECT COUNT(*) AS total
+       FROM "${schema}".agendamentos_lite
+       WHERE tenant_id = $1
+         AND data = $2
+         AND status IN ('agendado','pendente')`,
+      [tenantId, amanha]
+    ).catch(() => ({ rows: [{ total: 0 }] }));
+    const total = parseInt(rows[0]?.total || 0);
+    if (total > 0) {
+      await emitirAlertaInstantaneo(
+        tenantId, schema,
+        'recepcionista', 'sem_confirmacao', 'alta',
+        `${total} agendamento(s) amanhã sem confirmação`,
+        `Você tem ${total} agendamento(s) para amanhã ainda não confirmados. Entre em contato com os pacientes.`,
+        { total, data: amanha },
+        '/agenda'
+      );
+    }
+  } catch (err) {
+    console.error('[Detector sem_confirmacao]', err.message);
+  }
+}
+
+// ── Detector 2: Taxa de no-show alta hoje ─────────────────────────────────────
+async function detectarNoShowAlto(pool, tenantId, schema) {
+  try {
+    const hoje = getHoje();
+    const { rows } = await pool.query(
+      `SELECT
+         COUNT(*) FILTER (WHERE status IN ('realizado','no_show','cancelado')) AS total,
+         COUNT(*) FILTER (WHERE status = 'no_show') AS no_shows
+       FROM "${schema}".agendamentos_lite
+       WHERE tenant_id = $1 AND data = $2`,
+      [tenantId, hoje]
+    ).catch(() => ({ rows: [{ total: 0, no_shows: 0 }] }));
+    const total = parseInt(rows[0]?.total || 0);
+    const noShows = parseInt(rows[0]?.no_shows || 0);
+    if (total >= 5 && noShows / total >= 0.25) {
+      await emitirAlertaInstantaneo(
+        tenantId, schema,
+        'admin', 'no_show_alto', 'alta',
+        `Taxa de no-show hoje: ${Math.round((noShows / total) * 100)}%`,
+        `${noShows} de ${total} atendimentos resultaram em no-show hoje. Considere reforçar confirmações.`,
+        { total, no_shows: noShows, taxa: noShows / total },
+        '/relatorios/no-show'
+      );
+    }
+  } catch (err) {
+    console.error('[Detector no_show_alto]', err.message);
+  }
+}
+
+// ── Detector 3: Fatura vencendo hoje ─────────────────────────────────────────
+async function detectarFaturasVencendoHoje(pool, tenantId, schema) {
+  try {
+    const hoje = getHoje();
+    const { rows } = await pool.query(
+      `SELECT COUNT(*) AS total, COALESCE(SUM(valor),0) AS valor
+       FROM "${schema}".faturas
+       WHERE tenant_id = $1
+         AND status = 'aguardando'
+         AND vencimento::date = $2`,
+      [tenantId, hoje]
+    ).catch(() => ({ rows: [{ total: 0, valor: 0 }] }));
+    const total = parseInt(rows[0]?.total || 0);
+    const valor = parseFloat(rows[0]?.valor || 0);
+    if (total > 0) {
+      await emitirAlertaInstantaneo(
+        tenantId, schema,
+        'financeiro', 'fatura_vencendo_hoje', 'alta',
+        `${total} fatura(s) vencem hoje`,
+        `Total de R$ ${valor.toFixed(2)} em faturas com vencimento hoje ainda em aberto.`,
+        { total, valor },
+        '/financeiro/faturas'
+      );
+    }
+  } catch (err) {
+    console.error('[Detector fatura_vencendo_hoje]', err.message);
+  }
+}
+
+// ── Detector 4: Alta inadimplência (> 20% das faturas do mês) ────────────────
+async function detectarInadimplenciaAlta(pool, tenantId, schema) {
+  try {
+    const mesAtual = new Date().toISOString().slice(0, 7); // YYYY-MM
+    const { rows } = await pool.query(
+      `SELECT
+         COUNT(*) AS total,
+         COUNT(*) FILTER (WHERE status = 'vencida') AS vencidas,
+         COALESCE(SUM(valor) FILTER (WHERE status = 'vencida'), 0) AS valor_vencido
+       FROM "${schema}".faturas
+       WHERE tenant_id = $1
+         AND to_char(criado_em, 'YYYY-MM') = $2
+         AND status NOT IN ('cancelada')`,
+      [tenantId, mesAtual]
+    ).catch(() => ({ rows: [{ total: 0, vencidas: 0, valor_vencido: 0 }] }));
+    const total = parseInt(rows[0]?.total || 0);
+    const vencidas = parseInt(rows[0]?.vencidas || 0);
+    const valorVencido = parseFloat(rows[0]?.valor_vencido || 0);
+    if (total >= 5 && vencidas / total >= 0.20) {
+      await emitirAlertaInstantaneo(
+        tenantId, schema,
+        'financeiro', 'inadimplencia_alta', 'critica',
+        `Inadimplência: ${Math.round((vencidas / total) * 100)}% das faturas do mês`,
+        `${vencidas} de ${total} faturas deste mês estão vencidas. Valor em aberto: R$ ${valorVencido.toFixed(2)}.`,
+        { total, vencidas, valor_vencido: valorVencido, taxa: vencidas / total },
+        '/financeiro/inadimplencia'
+      );
+    }
+  } catch (err) {
+    console.error('[Detector inadimplencia_alta]', err.message);
+  }
+}
+
+// ── Detector 5: Fila de espera longa (> 10 pacientes) ────────────────────────
+async function detectarFilaLonga(pool, tenantId, schema) {
+  try {
+    const { rows } = await pool.query(
+      `SELECT COUNT(*) AS total
+       FROM "${schema}".fila_espera
+       WHERE tenant_id = $1 AND status = 'aguardando'`,
+      [tenantId]
+    ).catch(() => ({ rows: [{ total: 0 }] }));
+    const total = parseInt(rows[0]?.total || 0);
+    if (total > 10) {
+      await emitirAlertaInstantaneo(
+        tenantId, schema,
+        'recepcionista', 'fila_longa', 'alta',
+        `Fila de espera: ${total} pacientes`,
+        `Há ${total} pacientes na fila de espera. Considere acionar mais profissionais ou reorganizar a agenda.`,
+        { total },
+        '/fila'
+      );
+    }
+  } catch (err) {
+    console.error('[Detector fila_longa]', err.message);
+  }
+}
+
+// ── Detector 6: Meta de receita em risco (< 60% do mês a 70% do tempo) ───────
+async function detectarMetaReceitaRisco(pool, tenantId, schema) {
+  try {
+    const hoje = new Date();
+    const diasNoMes = new Date(hoje.getFullYear(), hoje.getMonth() + 1, 0).getDate();
+    const diaAtual = hoje.getDate();
+    const percTempo = diaAtual / diasNoMes;
+    if (percTempo < 0.70) return; // Só alertar a partir de 70% do mês
+
+    const mesAtual = hoje.toISOString().slice(0, 7);
+    const [receitaRes, metaRes] = await Promise.all([
+      pool.query(
+        `SELECT COALESCE(SUM(f.valor), 0) AS receita
+         FROM "${schema}".faturas f
+         WHERE f.tenant_id = $1
+           AND f.status = 'pago'
+           AND to_char(f.criado_em, 'YYYY-MM') = $2`,
+        [tenantId, mesAtual]
+      ).catch(() => ({ rows: [{ receita: 0 }] })),
+      pool.query(
+        `SELECT valor_meta FROM "${schema}".metas_dashboard
+         WHERE tenant_id = $1 AND tipo = 'receita' AND mes = $2`,
+        [tenantId, mesAtual]
+      ).catch(() => ({ rows: [] }))
+    ]);
+    const meta = parseFloat(metaRes.rows[0]?.valor_meta || 0);
+    if (!meta) return;
+    const receita = parseFloat(receitaRes.rows[0]?.receita || 0);
+    const pctMeta = receita / meta;
+    if (pctMeta < 0.60) {
+      await emitirAlertaInstantaneo(
+        tenantId, schema,
+        'admin', 'meta_receita_risco', 'critica',
+        `Meta de receita em risco: ${Math.round(pctMeta * 100)}% atingida`,
+        `Estamos a ${Math.round(percTempo * 100)}% do mês e a receita atingiu apenas ${Math.round(pctMeta * 100)}% da meta (R$ ${receita.toFixed(2)} de R$ ${meta.toFixed(2)}).`,
+        { receita, meta, pct_meta: pctMeta, pct_tempo: percTempo },
+        '/relatorios/receita'
+      );
+    }
+  } catch (err) {
+    console.error('[Detector meta_receita_risco]', err.message);
+  }
+}
+
+// ── Detector 7: Paciente de alto risco financeiro sem cobrança ────────────────
+async function detectarAltoRiscoSemCobranca(pool, tenantId, schema) {
+  try {
+    const { rows } = await pool.query(
+      `SELECT COUNT(*) AS total
+       FROM "${schema}".faturas f
+       LEFT JOIN "${schema}".ia_scores_financeiros s ON s.paciente_id = f.paciente_id AND s.tenant_id = f.tenant_id
+       WHERE f.tenant_id = $1
+         AND f.status = 'vencida'
+         AND s.score_risco >= 70
+         AND NOT EXISTS (
+           SELECT 1 FROM "${schema}".cobrancas_whatsapp c
+           WHERE c.fatura_id = f.id AND c.enviado_em > NOW() - INTERVAL '3 days'
+         )`,
+      [tenantId]
+    ).catch(() => ({ rows: [{ total: 0 }] }));
+    const total = parseInt(rows[0]?.total || 0);
+    if (total > 0) {
+      await emitirAlertaInstantaneo(
+        tenantId, schema,
+        'financeiro', 'alto_risco_sem_cobranca', 'alta',
+        `${total} paciente(s) de alto risco sem cobrança recente`,
+        `${total} fatura(s) de pacientes com alto risco financeiro estão vencidas sem cobrança nos últimos 3 dias.`,
+        { total },
+        '/financeiro/inadimplencia'
+      );
+    }
+  } catch (err) {
+    console.error('[Detector alto_risco_sem_cobranca]', err.message);
+  }
+}
+
+// ── Detector 8: Oportunidades CRM sem follow-up (> 7 dias) ───────────────────
+async function detectarOportunidadesSemFollowup(pool, tenantId, schema) {
+  try {
+    const { rows } = await pool.query(
+      `SELECT COUNT(*) AS total
+       FROM "${schema}".crm_oportunidades
+       WHERE tenant_id = $1
+         AND status NOT IN ('fechado_ganho','fechado_perdido')
+         AND (ultimo_contato IS NULL OR ultimo_contato < NOW() - INTERVAL '7 days')`,
+      [tenantId]
+    ).catch(() => ({ rows: [{ total: 0 }] }));
+    const total = parseInt(rows[0]?.total || 0);
+    if (total > 0) {
+      await emitirAlertaInstantaneo(
+        tenantId, schema,
+        'admin', 'oportunidades_sem_followup', 'normal',
+        `${total} oportunidade(s) CRM sem follow-up há mais de 7 dias`,
+        `${total} oportunidades ativas no CRM estão sem contato há mais de 7 dias e podem esfriar.`,
+        { total },
+        '/crm'
+      );
+    }
+  } catch (err) {
+    console.error('[Detector oportunidades_sem_followup]', err.message);
+  }
+}
+
+// ── Detector 9: Muitas mensagens WhatsApp não respondidas (> 5) ───────────────
+async function detectarWhatsAppNaoRespondido(pool, tenantId, schema) {
+  try {
+    const { rows } = await pool.query(
+      `SELECT COUNT(DISTINCT conversa_id) AS total
+       FROM "${schema}".whatsapp_inbox
+       WHERE tenant_id = $1
+         AND respondido = false
+         AND criado_em < NOW() - INTERVAL '2 hours'`,
+      [tenantId]
+    ).catch(() => ({ rows: [{ total: 0 }] }));
+    const total = parseInt(rows[0]?.total || 0);
+    if (total >= 5) {
+      await emitirAlertaInstantaneo(
+        tenantId, schema,
+        'recepcionista', 'whatsapp_nao_respondido', 'alta',
+        `${total} conversa(s) WhatsApp sem resposta há mais de 2h`,
+        `Há ${total} conversas no WhatsApp aguardando resposta há mais de 2 horas.`,
+        { total },
+        '/whatsapp'
+      );
+    }
+  } catch (err) {
+    console.error('[Detector whatsapp_nao_respondido]', err.message);
+  }
+}
+
+// ── Detector 10: Profissional sem agendamentos amanhã (agenda vazia) ──────────
+async function detectarAgendaVaziaAmanha(pool, tenantId, schema) {
+  try {
+    const amanha = getAmanha();
+    const { rows } = await pool.query(
+      `SELECT p.id, p.nome,
+         COUNT(a.id) AS agendamentos
+       FROM "${schema}".profissionais p
+       LEFT JOIN "${schema}".agendamentos_lite a
+         ON a.profissional_id = p.id AND a.data = $2 AND a.tenant_id = $1
+       WHERE p.tenant_id = $1 AND p.ativo = true
+       GROUP BY p.id, p.nome
+       HAVING COUNT(a.id) = 0`,
+      [tenantId, amanha]
+    ).catch(() => ({ rows: [] }));
+    if (rows.length > 0) {
+      const nomes = rows.map(r => r.nome).join(', ');
+      await emitirAlertaInstantaneo(
+        tenantId, schema,
+        'admin', 'agenda_vazia_amanha', 'baixa',
+        `${rows.length} profissional(is) sem agenda amanhã`,
+        `Os seguintes profissionais não têm agendamentos para amanhã: ${nomes}.`,
+        { profissionais: rows.map(r => ({ id: r.id, nome: r.nome })) },
+        '/agenda'
+      );
+    }
+  } catch (err) {
+    console.error('[Detector agenda_vazia_amanha]', err.message);
+  }
+}
+
+// ── Detector 11: Paciente retorno atrasado (> 90 dias sem voltar) ─────────────
+async function detectarRetornoAtrasado(pool, tenantId, schema) {
+  try {
+    const { rows } = await pool.query(
+      `SELECT COUNT(DISTINCT paciente_id) AS total
+       FROM "${schema}".agendamentos_lite
+       WHERE tenant_id = $1
+         AND status = 'realizado'
+         AND paciente_id NOT IN (
+           SELECT DISTINCT paciente_id
+           FROM "${schema}".agendamentos_lite
+           WHERE tenant_id = $1
+             AND data > (CURRENT_DATE - INTERVAL '90 days')
+         )
+         AND data = (
+           SELECT MAX(data)
+           FROM "${schema}".agendamentos_lite a2
+           WHERE a2.paciente_id = agendamentos_lite.paciente_id
+             AND a2.tenant_id = $1
+             AND a2.status = 'realizado'
+         )
+         AND data < (CURRENT_DATE - INTERVAL '90 days')
+         AND data > (CURRENT_DATE - INTERVAL '180 days')`,
+      [tenantId]
+    ).catch(() => ({ rows: [{ total: 0 }] }));
+    const total = parseInt(rows[0]?.total || 0);
+    if (total >= 10) {
+      await emitirAlertaInstantaneo(
+        tenantId, schema,
+        'admin', 'retorno_atrasado', 'normal',
+        `${total} paciente(s) sem retorno há mais de 90 dias`,
+        `${total} pacientes que realizaram consulta estão há mais de 90 dias sem novo agendamento. Considere campanhas de reativação.`,
+        { total },
+        '/pacientes'
+      );
+    }
+  } catch (err) {
+    console.error('[Detector retorno_atrasado]', err.message);
+  }
+}
+
+// ── Detector 12: Receita do dia abaixo do esperado ────────────────────────────
+async function detectarReceitaDiaAbaixo(pool, tenantId, schema) {
+  try {
+    const hoje = getHoje();
+    const mesAtual = hoje.slice(0, 7);
+    const [receitaHoje, metaRes] = await Promise.all([
+      pool.query(
+        `SELECT COALESCE(SUM(f.valor), 0) AS receita
+         FROM "${schema}".faturas f
+         WHERE f.tenant_id = $1
+           AND f.status = 'pago'
+           AND f.criado_em::date = $2`,
+        [tenantId, hoje]
+      ).catch(() => ({ rows: [{ receita: 0 }] })),
+      pool.query(
+        `SELECT valor_meta FROM "${schema}".metas_dashboard
+         WHERE tenant_id = $1 AND tipo = 'receita' AND mes = $2`,
+        [tenantId, mesAtual]
+      ).catch(() => ({ rows: [] }))
+    ]);
+    const meta = parseFloat(metaRes.rows[0]?.valor_meta || 0);
+    if (!meta) return;
+    const diasNoMes = new Date(
+      new Date().getFullYear(), new Date().getMonth() + 1, 0
+    ).getDate();
+    const metaDia = meta / diasNoMes;
+    const receita = parseFloat(receitaHoje.rows[0]?.receita || 0);
+    if (receita < metaDia * 0.5) {
+      await emitirAlertaInstantaneo(
+        tenantId, schema,
+        'financeiro', 'receita_dia_abaixo', 'normal',
+        `Receita de hoje abaixo do esperado`,
+        `Receita de hoje: R$ ${receita.toFixed(2)}. Esperado (meta diária): R$ ${metaDia.toFixed(2)}. Abaixo de 50% da meta.`,
+        { receita, meta_dia: metaDia },
+        '/financeiro'
+      );
+    }
+  } catch (err) {
+    console.error('[Detector receita_dia_abaixo]', err.message);
+  }
+}
+
+// ── Orquestrador principal ─────────────────────────────────────────────────────
+async function detectarAlertas(pool, tenantId, schema) {
+  await Promise.allSettled([
+    detectarSemConfirmacao(pool, tenantId, schema),
+    detectarNoShowAlto(pool, tenantId, schema),
+    detectarFaturasVencendoHoje(pool, tenantId, schema),
+    detectarInadimplenciaAlta(pool, tenantId, schema),
+    detectarFilaLonga(pool, tenantId, schema),
+    detectarMetaReceitaRisco(pool, tenantId, schema),
+    detectarAltoRiscoSemCobranca(pool, tenantId, schema),
+    detectarOportunidadesSemFollowup(pool, tenantId, schema),
+    detectarWhatsAppNaoRespondido(pool, tenantId, schema),
+    detectarAgendaVaziaAmanha(pool, tenantId, schema),
+    detectarRetornoAtrasado(pool, tenantId, schema),
+    detectarReceitaDiaAbaixo(pool, tenantId, schema),
+  ]);
+}
+
+module.exports = { detectarAlertas };

--- a/src/services/briefing-prompts.js
+++ b/src/services/briefing-prompts.js
@@ -1,0 +1,106 @@
+/**
+ * briefing-prompts.js — monta prompts para o briefing diário IA do dashboard
+ */
+
+/**
+ * Monta o prompt de briefing para Claude com base nos KPIs do dia.
+ * @param {Object} kpis  — dados do dashboard (agendamentos, receita, alertas etc.)
+ * @param {string} perfil — perfil do usuário ('admin','medico','recepcionista','financeiro')
+ * @param {string} nomeClinica — nome da clínica
+ * @returns {string} prompt pronto para enviar ao modelo
+ */
+function buildBriefingPrompt(kpis, perfil, nomeClinica) {
+  const hoje = new Date().toLocaleDateString('pt-BR', {
+    weekday: 'long', day: '2-digit', month: 'long', year: 'numeric'
+  });
+
+  const base = `Você é o assistente de gestão da clínica "${nomeClinica}". Hoje é ${hoje}.
+Gere um briefing executivo conciso (máx. 200 palavras) para o perfil "${perfil}".
+Seja direto, use linguagem profissional e destaque pontos de atenção.`;
+
+  switch (perfil) {
+    case 'admin': {
+      const {
+        agendamentos_hoje = 0,
+        confirmados = 0,
+        no_shows = 0,
+        receita_mes = 0,
+        meta_receita = 0,
+        inadimplencia_valor = 0,
+        alertas_criticos = 0
+      } = kpis;
+      const pct = meta_receita > 0 ? Math.round((receita_mes / meta_receita) * 100) : 0;
+      return `${base}
+
+Dados de hoje:
+- Agendamentos: ${agendamentos_hoje} (${confirmados} confirmados, ${no_shows} no-shows)
+- Receita do mês: R$ ${Number(receita_mes).toFixed(2)} de meta R$ ${Number(meta_receita).toFixed(2)} (${pct}%)
+- Inadimplência em aberto: R$ ${Number(inadimplencia_valor).toFixed(2)}
+- Alertas críticos: ${alertas_criticos}
+
+Briefing:`;
+    }
+
+    case 'medico': {
+      const {
+        pacientes_hoje = 0,
+        primeira_consulta = 0,
+        retornos = 0,
+        duracao_media_min = 0
+      } = kpis;
+      return `${base}
+
+Agenda de hoje:
+- Total de pacientes: ${pacientes_hoje} (${primeira_consulta} primeiras consultas, ${retornos} retornos)
+- Duração média prevista por atendimento: ${duracao_media_min} minutos
+
+Briefing:`;
+    }
+
+    case 'recepcionista': {
+      const {
+        agendamentos_hoje = 0,
+        aguardando_confirmacao = 0,
+        checkins_pendentes = 0,
+        fila_atual = 0
+      } = kpis;
+      return `${base}
+
+Situação atual:
+- Agendamentos hoje: ${agendamentos_hoje}
+- Aguardando confirmação: ${aguardando_confirmacao}
+- Check-ins pendentes: ${checkins_pendentes}
+- Na fila de espera agora: ${fila_atual}
+
+Briefing:`;
+    }
+
+    case 'financeiro': {
+      const {
+        receita_mes = 0,
+        meta_receita = 0,
+        faturas_vencidas = 0,
+        valor_vencido = 0,
+        cobradas_hoje = 0
+      } = kpis;
+      const pct = meta_receita > 0 ? Math.round((receita_mes / meta_receita) * 100) : 0;
+      return `${base}
+
+Situação financeira:
+- Receita do mês: R$ ${Number(receita_mes).toFixed(2)} / meta R$ ${Number(meta_receita).toFixed(2)} (${pct}%)
+- Faturas vencidas: ${faturas_vencidas} (total R$ ${Number(valor_vencido).toFixed(2)})
+- Cobranças enviadas hoje: ${cobradas_hoje}
+
+Briefing:`;
+    }
+
+    default:
+      return `${base}
+
+Dados: ${JSON.stringify(kpis, null, 2)}
+
+Briefing:`;
+  }
+}
+
+module.exports = { buildBriefingPrompt };

--- a/src/services/cache-invalidation.js
+++ b/src/services/cache-invalidation.js
@@ -1,0 +1,47 @@
+/**
+ * cache-invalidation.js — helpers para invalidar cache do dashboard IA
+ * Aceita (tenantId, schema) — schema pode ser omitido (será resolvido via DB).
+ */
+const pool = require('../database/postgres');
+
+async function resolveSchema(tenantId, schemaHint) {
+  if (schemaHint) return schemaHint;
+  const { rows } = await pool.query(
+    'SELECT slug FROM public.tenants WHERE id = $1',
+    [tenantId]
+  ).catch(() => ({ rows: [] }));
+  if (!rows[0]) return null;
+  return require('./CrmScoreService').schemaFromSlug(rows[0].slug);
+}
+
+async function invalidarCacheFinanceiro(tenantId, schema) {
+  const s = await resolveSchema(tenantId, schema);
+  if (!s) return;
+  await pool.query(
+    `DELETE FROM "${s}".dashboard_cache
+     WHERE tenant_id = $1 AND perfil IN ('admin','financeiro') AND tipo = 'kpis'`,
+    [tenantId]
+  ).catch(() => {});
+}
+
+async function invalidarCacheAgenda(tenantId, schema) {
+  const s = await resolveSchema(tenantId, schema);
+  if (!s) return;
+  await pool.query(
+    `DELETE FROM "${s}".dashboard_cache
+     WHERE tenant_id = $1 AND tipo IN ('kpis','agenda_hoje')`,
+    [tenantId]
+  ).catch(() => {});
+}
+
+async function invalidarCacheRecepcionista(tenantId, schema) {
+  const s = await resolveSchema(tenantId, schema);
+  if (!s) return;
+  await pool.query(
+    `DELETE FROM "${s}".dashboard_cache
+     WHERE tenant_id = $1 AND perfil = 'recepcionista' AND tipo = 'kpis'`,
+    [tenantId]
+  ).catch(() => {});
+}
+
+module.exports = { invalidarCacheFinanceiro, invalidarCacheAgenda, invalidarCacheRecepcionista };

--- a/src/websocket/alertas.js
+++ b/src/websocket/alertas.js
@@ -1,0 +1,57 @@
+/**
+ * websocket/alertas.js — helpers para emissão de alertas proativos via socket.io
+ * O servidor socket.io já está configurado em src/server.js.
+ */
+const pool = require('../database/postgres');
+
+function getIo() {
+  try { return require('../server').io; } catch { return null; }
+}
+
+/**
+ * Emite um alerta já persistido para a sala do tenant.
+ * @param {string} tenantId
+ * @param {string|null} perfilAlvo — null = broadcast para todo o tenant
+ * @param {Object} alerta
+ */
+function emitirAlerta(tenantId, perfilAlvo, alerta) {
+  const io = getIo();
+  if (!io) return;
+  // Por enquanto emite para a sala do tenant inteira
+  io.to(`tenant:${tenantId}`).emit('alerta_proativo', { perfilAlvo, alerta });
+}
+
+/**
+ * Persiste um alerta no banco E emite via socket.io imediatamente.
+ *
+ * @param {string}  tenantId
+ * @param {string}  schema       — schema da clínica (ex: "clinica_minha-clinica")
+ * @param {string|null} perfilAlvo
+ * @param {string}  tipo
+ * @param {string}  prioridade   — 'baixa'|'normal'|'alta'|'critica'
+ * @param {string}  titulo
+ * @param {string}  mensagem
+ * @param {Object|null} dados
+ * @param {string|null} acaoUrl
+ * @param {number|null} usuarioId — destinatário específico (opcional)
+ * @returns {Promise<Object>} alerta inserido
+ */
+async function emitirAlertaInstantaneo(
+  tenantId, schema,
+  perfilAlvo, tipo, prioridade, titulo, mensagem,
+  dados = null, acaoUrl = null, usuarioId = null
+) {
+  const { rows } = await pool.query(
+    `INSERT INTO "${schema}".alertas_proativos
+       (tenant_id, usuario_id, perfil_alvo, tipo, prioridade, titulo, mensagem, dados_json, acao_url)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+     RETURNING *`,
+    [tenantId, usuarioId, perfilAlvo, tipo, prioridade, titulo, mensagem,
+     dados ? JSON.stringify(dados) : null, acaoUrl]
+  );
+  const alerta = rows[0];
+  emitirAlerta(tenantId, perfilAlvo, alerta);
+  return alerta;
+}
+
+module.exports = { emitirAlerta, emitirAlertaInstantaneo };


### PR DESCRIPTION
## O que foi feito
- Migration `033_dashboard_ia.sql`: tabelas dashboard_cache, alertas_proativos, dashboard_config, metas_dashboard + 7 índices
- `cache-invalidation.js`: invalidarCacheFinanceiro/Agenda/Recepcionista com resolveSchema via lookup public.tenants
- `briefing-prompts.js`: buildBriefingPrompt com prompts por perfil
- `alertas-detectores.js`: 12 detectores (fila longa, inadimplência, CRM frio, WhatsApp sem resposta, etc)
- `websocket/alertas.js`: emitirAlerta + emitirAlertaInstantaneo via require('../server').io
- `dashboard-ia.js`: 9 endpoints em /api/dashboard-ia (KPIs cache-first por perfil, briefing, alertas, config, metas)
- `jobs/dashboard-cache.js`: cron 0 * * * * — pré-calcula KPIs por tenant/perfil
- `jobs/briefing-diario.js`: cron 0 7 * * * — gera briefing com Claude
- `jobs/alertas-engine.js`: cron */5 * * * * — roda 12 detectores
- `app.js`: rota /api/dashboard-ia + 3 jobs registrados

## Testado em
Branch feature/dashboard-ia-tdd21

🤖 Generated with [Claude Code](https://claude.com/claude-code)